### PR TITLE
Resolves #10: travis ci config to run checkstyle as part of build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: java
 jdk:
   - oraclejdk8
+script: mvn test && mvn checkstyle:check


### PR DESCRIPTION
I'll be honest, I don't like having the test and checkstyle:check goals and-ed on the script line for travis, but unfortunately the after_script/after_success configuration for travis do not fail the build for non-zero exit codes (which is something they admittedly are wanting to change).  Anyway, this is a work around, but when travis fixes this issue, we should remove the script element I added (mvn test is implicit) and add:

     after_success: mvn checkstyle:check