### PR TITLE
Adjust checkstyle configuration and remove many pointless comments

### DIFF
--- a/build-tools/src/main/resources/checkstyle/checkstyle.xml
+++ b/build-tools/src/main/resources/checkstyle/checkstyle.xml
@@ -55,16 +55,6 @@
         <!-- see http://checkstyle.sourceforge.net/config_annotation.html#SuppressWarningsHolder -->
         <module name="SuppressWarningsHolder"/>
 
-        <!-- Checks for Javadoc comments.                     -->
-        <!-- See http://checkstyle.sf.net/config_javadoc.html -->
-        <module name="JavadocMethod">
-            <property name="severity" value="error"/>
-            <property name="allowMissingPropertyJavadoc" value="true"/>
-        </module>
-        <module name="JavadocType">
-            <property name="severity" value="error"/>
-        </module>
-        <!--<module name="JavadocVariable"/>-->
         <module name="JavadocStyle"/>
 
 
@@ -81,19 +71,21 @@
         <module name="TypeName"/>
 
         <!-- Checks for imports                              -->
-        <!-- See http://checkstyle.sf.net/config_import.html -->
-        <module name="AvoidStarImport">
-            <property name="severity" value="error"/>
-        </module>
+        <!-- See http://checkstyle.sf.net/config_imports.html -->
         <module name="IllegalImport"> <!-- defaults to sun.* packages -->
             <property name="severity" value="error"/>
-            <!--<property name="illegalPkgs" value="java.io, java.sql"/>-->
         </module>
         <module name="RedundantImport">
             <property name="severity" value="error"/>
         </module>
         <module name="UnusedImports">
             <property name="severity" value="error"/>
+        </module>
+        <module name="ImportOrder">
+            <property name="severity" value="error"/>
+            <property name="groups" value="org.coner"/>
+            <property name="option" value="bottom"/>
+            <property name="separated" value="true"/>
         </module>
 
 
@@ -168,7 +160,6 @@
 
         <!-- Checks for class design                         -->
         <!-- See http://checkstyle.sf.net/config_design.html -->
-        <!--<module name="DesignForExtension"/>-->
         <module name="FinalClass"/>
         <module name="HideUtilityClassConstructor"/>
         <module name="InterfaceIsType"/>

--- a/dropwizard-api/src/main/java/org/coner/api/entity/ApiEntity.java
+++ b/dropwizard-api/src/main/java/org/coner/api/entity/ApiEntity.java
@@ -2,7 +2,7 @@ package org.coner.api.entity;
 
 /**
  * An abstract superclass for all REST API entities
- * <p/>
+ * <p>
  * In order for an API entity to be converted through the core project's Boundary classes,
  * it will need to extend ApiEntity.
  */

--- a/dropwizard-api/src/main/java/org/coner/api/entity/CompetitionGroup.java
+++ b/dropwizard-api/src/main/java/org/coner/api/entity/CompetitionGroup.java
@@ -1,17 +1,10 @@
 package org.coner.api.entity;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import java.math.BigDecimal;
+import javax.validation.constraints.*;
 import org.hibernate.validator.constraints.NotBlank;
 
-import javax.validation.constraints.DecimalMax;
-import javax.validation.constraints.DecimalMin;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Null;
-import java.math.BigDecimal;
-
-/**
- * REST API entity representing a Competition Group.
- */
 @JsonPropertyOrder({"id", "name", "handicapFactor", "grouping", "resultTimeType"})
 public class CompetitionGroup extends ApiEntity {
 

--- a/dropwizard-api/src/main/java/org/coner/api/entity/CompetitionGroupSet.java
+++ b/dropwizard-api/src/main/java/org/coner/api/entity/CompetitionGroupSet.java
@@ -1,12 +1,8 @@
 package org.coner.api.entity;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-
 import java.util.Set;
 
-/**
- * REST API entity representing a Competition Group Set
- */
 @JsonPropertyOrder({"id", "name", "competitionGroups"})
 public class CompetitionGroupSet extends ApiEntity {
 

--- a/dropwizard-api/src/main/java/org/coner/api/entity/Event.java
+++ b/dropwizard-api/src/main/java/org/coner/api/entity/Event.java
@@ -1,15 +1,10 @@
 package org.coner.api.entity;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import java.util.Date;
+import javax.validation.constraints.*;
 import org.hibernate.validator.constraints.NotBlank;
 
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Null;
-import java.util.Date;
-
-/**
- * REST API entity representing an Event.
- */
 @JsonPropertyOrder({"id", "name", "date"})
 public class Event extends ApiEntity {
 

--- a/dropwizard-api/src/main/java/org/coner/api/entity/HandicapGroup.java
+++ b/dropwizard-api/src/main/java/org/coner/api/entity/HandicapGroup.java
@@ -1,16 +1,9 @@
 package org.coner.api.entity;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-
-import javax.validation.constraints.DecimalMax;
-import javax.validation.constraints.DecimalMin;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Null;
 import java.math.BigDecimal;
+import javax.validation.constraints.*;
 
-/**
- * REST API entity representing a HandicapGroup.
- */
 @JsonPropertyOrder({"id", "name", "handicapFactor"})
 public class HandicapGroup extends ApiEntity {
 

--- a/dropwizard-api/src/main/java/org/coner/api/entity/Registration.java
+++ b/dropwizard-api/src/main/java/org/coner/api/entity/Registration.java
@@ -1,14 +1,9 @@
 package org.coner.api.entity;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import javax.validation.constraints.*;
 import org.hibernate.validator.constraints.NotBlank;
 
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Null;
-
-/**
- * REST API entity representing a Registration.
- */
 @JsonPropertyOrder({"id", "firstName", "lastName", "event"})
 public class Registration extends ApiEntity {
 

--- a/dropwizard-api/src/main/java/org/coner/api/request/AddCompetitionGroupRequest.java
+++ b/dropwizard-api/src/main/java/org/coner/api/request/AddCompetitionGroupRequest.java
@@ -2,8 +2,5 @@ package org.coner.api.request;
 
 import org.coner.api.entity.CompetitionGroup;
 
-/**
- * API request body used when adding a new CompetitionGroup.
- */
 public class AddCompetitionGroupRequest extends CompetitionGroup {
 }

--- a/dropwizard-api/src/main/java/org/coner/api/request/AddCompetitionGroupSetRequest.java
+++ b/dropwizard-api/src/main/java/org/coner/api/request/AddCompetitionGroupSetRequest.java
@@ -1,13 +1,8 @@
 package org.coner.api.request;
 
-
+import java.util.Set;
 import org.hibernate.validator.constraints.NotBlank;
 
-import java.util.Set;
-
-/**
- * API request body used when adding a new CompetitionGroupSet
- */
 public class AddCompetitionGroupSetRequest {
 
     @NotBlank

--- a/dropwizard-api/src/main/java/org/coner/api/request/AddEventRequest.java
+++ b/dropwizard-api/src/main/java/org/coner/api/request/AddEventRequest.java
@@ -1,11 +1,7 @@
 package org.coner.api.request;
 
-
 import org.coner.api.entity.Event;
 
-/**
- * API request body used when adding a new Event.
- */
 public class AddEventRequest extends Event {
 
 }

--- a/dropwizard-api/src/main/java/org/coner/api/request/AddHandicapGroupRequest.java
+++ b/dropwizard-api/src/main/java/org/coner/api/request/AddHandicapGroupRequest.java
@@ -2,8 +2,5 @@ package org.coner.api.request;
 
 import org.coner.api.entity.HandicapGroup;
 
-/**
- * API request body used when adding a new HandicapGroup.
- */
 public class AddHandicapGroupRequest extends HandicapGroup {
 }

--- a/dropwizard-api/src/main/java/org/coner/api/request/AddRegistrationRequest.java
+++ b/dropwizard-api/src/main/java/org/coner/api/request/AddRegistrationRequest.java
@@ -2,8 +2,5 @@ package org.coner.api.request;
 
 import org.coner.api.entity.Registration;
 
-/**
- * API request body used when adding a new Registration.
- */
 public class AddRegistrationRequest extends Registration {
 }

--- a/dropwizard-api/src/main/java/org/coner/api/response/ErrorsResponse.java
+++ b/dropwizard-api/src/main/java/org/coner/api/response/ErrorsResponse.java
@@ -1,12 +1,8 @@
 package org.coner.api.response;
 
 import com.google.common.collect.ImmutableList;
-
 import java.util.List;
 
-/**
- * API response object when one or more errors occurred.
- */
 public class ErrorsResponse {
 
     private ImmutableList<String> errors;

--- a/dropwizard-api/src/main/java/org/coner/api/response/GetCompetitionGroupsResponse.java
+++ b/dropwizard-api/src/main/java/org/coner/api/response/GetCompetitionGroupsResponse.java
@@ -4,10 +4,6 @@ import org.coner.api.entity.CompetitionGroup;
 
 import java.util.List;
 
-/**
- * API response object containing a list of CompeititionGroup entities.
- */
-
 public class GetCompetitionGroupsResponse {
     private List<CompetitionGroup> competitionGroups;
 

--- a/dropwizard-api/src/main/java/org/coner/api/response/GetEventRegistrationsResponse.java
+++ b/dropwizard-api/src/main/java/org/coner/api/response/GetEventRegistrationsResponse.java
@@ -4,9 +4,6 @@ import org.coner.api.entity.Registration;
 
 import java.util.List;
 
-/**
- * API response object containing a list of Registration entities for an Event.
- */
 public class GetEventRegistrationsResponse {
 
     private List<Registration> registrations;

--- a/dropwizard-api/src/main/java/org/coner/api/response/GetEventsResponse.java
+++ b/dropwizard-api/src/main/java/org/coner/api/response/GetEventsResponse.java
@@ -5,9 +5,6 @@ import org.coner.api.entity.Event;
 
 import java.util.List;
 
-/**
- * API response object containing a list of Event entities.
- */
 public class GetEventsResponse {
 
     private List<Event> events;

--- a/dropwizard-api/src/main/java/org/coner/api/response/GetHandicapGroupsResponse.java
+++ b/dropwizard-api/src/main/java/org/coner/api/response/GetHandicapGroupsResponse.java
@@ -4,9 +4,6 @@ import org.coner.api.entity.HandicapGroup;
 
 import java.util.List;
 
-/**
- * API response object containing a list of HandicapGroup entities.
- */
 public class GetHandicapGroupsResponse {
     private List<HandicapGroup> handicapGroups;
 

--- a/dropwizard-app/src/main/java/org/coner/ConerDropwizardApplication.java
+++ b/dropwizard-app/src/main/java/org/coner/ConerDropwizardApplication.java
@@ -1,49 +1,21 @@
 package org.coner;
 
+import org.coner.boundary.*;
+import org.coner.core.ConerCoreService;
+import org.coner.core.gateway.*;
+import org.coner.exception.WebApplicationExceptionMapper;
+import org.coner.hibernate.dao.*;
+import org.coner.hibernate.entity.*;
+import org.coner.resource.*;
+import org.coner.util.JacksonUtil;
+
 import io.dropwizard.Application;
 import io.dropwizard.db.DataSourceFactory;
 import io.dropwizard.hibernate.HibernateBundle;
 import io.dropwizard.jersey.setup.JerseyEnvironment;
-import io.dropwizard.setup.Bootstrap;
-import io.dropwizard.setup.Environment;
-import io.federecio.dropwizard.swagger.SwaggerBundle;
-import io.federecio.dropwizard.swagger.SwaggerBundleConfiguration;
-import org.coner.boundary.CompetitionGroupBoundary;
-import org.coner.boundary.CompetitionGroupSetBoundary;
-import org.coner.boundary.EventBoundary;
-import org.coner.boundary.HandicapGroupBoundary;
-import org.coner.boundary.RegistrationBoundary;
-import org.coner.core.ConerCoreService;
-import org.coner.core.gateway.CompetitionGroupGateway;
-import org.coner.core.gateway.CompetitionGroupSetGateway;
-import org.coner.core.gateway.EventGateway;
-import org.coner.core.gateway.HandicapGroupGateway;
-import org.coner.core.gateway.RegistrationGateway;
-import org.coner.exception.WebApplicationExceptionMapper;
-import org.coner.hibernate.dao.CompetitionGroupDao;
-import org.coner.hibernate.dao.CompetitionGroupSetDao;
-import org.coner.hibernate.dao.EventDao;
-import org.coner.hibernate.dao.HandicapGroupDao;
-import org.coner.hibernate.dao.RegistrationDao;
-import org.coner.hibernate.entity.CompetitionGroup;
-import org.coner.hibernate.entity.CompetitionGroupSet;
-import org.coner.hibernate.entity.Event;
-import org.coner.hibernate.entity.HandicapGroup;
-import org.coner.hibernate.entity.Registration;
-import org.coner.resource.CompetitionGroupResource;
-import org.coner.resource.CompetitionGroupSetsResource;
-import org.coner.resource.CompetitionGroupsResource;
-import org.coner.resource.EventRegistrationResource;
-import org.coner.resource.EventRegistrationsResource;
-import org.coner.resource.EventResource;
-import org.coner.resource.EventsResource;
-import org.coner.resource.HandicapGroupResource;
-import org.coner.resource.HandicapGroupsResource;
-import org.coner.util.JacksonUtil;
+import io.dropwizard.setup.*;
+import io.federecio.dropwizard.swagger.*;
 
-/**
- * The Dropwizard application which exposes the Coner core REST interface.
- */
 public class ConerDropwizardApplication extends Application<ConerDropwizardConfiguration> {
 
     private HibernateBundle<ConerDropwizardConfiguration> hibernate;
@@ -64,12 +36,6 @@ public class ConerDropwizardApplication extends Application<ConerDropwizardConfi
     private HandicapGroupGateway handicapGroupGateway;
     private ConerCoreService conerCoreService;
 
-    /**
-     * The main method of the application.
-     *
-     * @param args raw String arguments
-     * @throws Exception any uncaught exception
-     */
     public static void main(String[] args) throws Exception {
         new ConerDropwizardApplication().run(args);
     }
@@ -151,11 +117,6 @@ public class ConerDropwizardApplication extends Application<ConerDropwizardConfi
 
     }
 
-    /**
-     * Lazy initializer for the HibernateBundle.
-     *
-     * @return the HibernateBundle
-     */
     private HibernateBundle<ConerDropwizardConfiguration> getHibernate() {
         if (hibernate == null) {
             hibernate = new HibernateBundle<ConerDropwizardConfiguration>(
@@ -179,11 +140,6 @@ public class ConerDropwizardApplication extends Application<ConerDropwizardConfi
         this.hibernate = hibernate;
     }
 
-    /**
-     * Lazy initializer for the EventBoundary.
-     *
-     * @return the EventBoundary
-     */
     private EventBoundary getEventBoundary() {
         if (eventBoundary == null) {
             eventBoundary = new EventBoundary();
@@ -195,11 +151,6 @@ public class ConerDropwizardApplication extends Application<ConerDropwizardConfi
         this.eventBoundary = eventBoundary;
     }
 
-    /**
-     * Lazy initializer for the EventDao.
-     *
-     * @return the EventDao
-     */
     private EventDao getEventDao() {
         if (eventDao == null) {
             eventDao = new EventDao(getHibernate().getSessionFactory());
@@ -211,11 +162,6 @@ public class ConerDropwizardApplication extends Application<ConerDropwizardConfi
         this.eventDao = eventDao;
     }
 
-    /**
-     * Lazy initializer for the EventGateway.
-     *
-     * @return the EventGateway
-     */
     private EventGateway getEventGateway() {
         if (eventGateway == null) {
             eventGateway = new EventGateway(getEventBoundary(), getEventDao());
@@ -227,11 +173,6 @@ public class ConerDropwizardApplication extends Application<ConerDropwizardConfi
         this.eventGateway = eventGateway;
     }
 
-    /**
-     * Lazy initializer for RegistrationBoundary.
-     *
-     * @return the RegistrationBoundary
-     */
     private RegistrationBoundary getRegistrationBoundary() {
         if (registrationBoundary == null) {
             registrationBoundary = new RegistrationBoundary(getEventBoundary());
@@ -243,11 +184,6 @@ public class ConerDropwizardApplication extends Application<ConerDropwizardConfi
         this.registrationBoundary = registrationBoundary;
     }
 
-    /**
-     * Lazy initializer for the RegistrationDao.
-     *
-     * @return the RegistrationDao
-     */
     private RegistrationDao getRegistrationDao() {
         if (registrationDao == null) {
             registrationDao = new RegistrationDao(getHibernate().getSessionFactory());
@@ -259,11 +195,6 @@ public class ConerDropwizardApplication extends Application<ConerDropwizardConfi
         this.registrationDao = registrationDao;
     }
 
-    /**
-     * Lazy initializer for the RegistrationGateway.
-     *
-     * @return the RegistrationGateway
-     */
     private RegistrationGateway getRegistrationGateway() {
         if (registrationGateway == null) {
             registrationGateway = new RegistrationGateway(
@@ -279,11 +210,6 @@ public class ConerDropwizardApplication extends Application<ConerDropwizardConfi
         this.registrationGateway = registrationGateway;
     }
 
-    /**
-     * Lazy initializer for the HandicapGroupBoundary.
-     *
-     * @return the HandicapGroupBoundary
-     */
     private HandicapGroupBoundary getHandicapGroupBoundary() {
         if (handicapGroupBoundary == null) {
             handicapGroupBoundary = new HandicapGroupBoundary();
@@ -295,11 +221,6 @@ public class ConerDropwizardApplication extends Application<ConerDropwizardConfi
         this.handicapGroupBoundary = handicapGroupBoundary;
     }
 
-    /**
-     * Lazy initializer for the HandicapGroupDao.
-     *
-     * @return the HandicapGroupDao
-     */
     private HandicapGroupDao getHandicapGroupDao() {
         if (handicapGroupDao == null) {
             handicapGroupDao = new HandicapGroupDao(getHibernate().getSessionFactory());
@@ -311,11 +232,6 @@ public class ConerDropwizardApplication extends Application<ConerDropwizardConfi
         this.handicapGroupDao = handicapGroupDao;
     }
 
-    /**
-     * Lazy initializer for the HandicapGroupGateway.
-     *
-     * @return the EventGateway
-     */
     private HandicapGroupGateway getHandicapGroupGateway() {
         if (handicapGroupGateway == null) {
             handicapGroupGateway = new HandicapGroupGateway(getHandicapGroupBoundary(), getHandicapGroupDao());
@@ -327,11 +243,6 @@ public class ConerDropwizardApplication extends Application<ConerDropwizardConfi
         this.handicapGroupGateway = handicapGroupGateway;
     }
 
-    /**
-     * Lazy initializer for the CompetitionGroupBoundary.
-     *
-     * @return the CompetitionGroupBoundary
-     */
     private CompetitionGroupBoundary getCompetitionGroupBoundary() {
         if (competitionGroupBoundary == null) {
             competitionGroupBoundary = new CompetitionGroupBoundary();
@@ -343,11 +254,6 @@ public class ConerDropwizardApplication extends Application<ConerDropwizardConfi
         this.competitionGroupBoundary = competitionGroupBoundary;
     }
 
-    /**
-     * Lazy initializer for the CompetitionGroupDao.
-     *
-     * @return the CompetitionGroupDao
-     */
     private CompetitionGroupDao getCompetitionGroupDao() {
         if (competitionGroupDao == null) {
             competitionGroupDao = new CompetitionGroupDao(getHibernate().getSessionFactory());
@@ -359,11 +265,6 @@ public class ConerDropwizardApplication extends Application<ConerDropwizardConfi
         this.competitionGroupDao = competitionGroupDao;
     }
 
-    /**
-     * Lazy initializer for the CompetitionGroupGateway.
-     *
-     * @return the CompetitionGroupGateway
-     */
     private CompetitionGroupGateway getCompetitionGroupGateway() {
         if (competitionGroupGateway == null) {
             this.competitionGroupGateway = new CompetitionGroupGateway(
@@ -378,11 +279,6 @@ public class ConerDropwizardApplication extends Application<ConerDropwizardConfi
         this.competitionGroupGateway = competitionGroupGateway;
     }
 
-    /**
-     * Lazy initializer for the CompetitionGroupSetGateway
-     *
-     * @return the CompetitionGroupSetGateway
-     */
     private CompetitionGroupSetGateway getCompetitionGroupSetGateway() {
         if (competitionGroupSetGateway == null) {
             competitionGroupSetGateway = new CompetitionGroupSetGateway(
@@ -397,11 +293,6 @@ public class ConerDropwizardApplication extends Application<ConerDropwizardConfi
         this.competitionGroupSetGateway = competitionGroupSetGateway;
     }
 
-    /**
-     * Lazy initializer for the CompetitionGroupSetBoundary
-     *
-     * @return the CompetitionGroupSetBoundary
-     */
     private CompetitionGroupSetBoundary getCompetitionGroupSetBoundary() {
         if (competitionGroupSetBoundary == null) {
             competitionGroupSetBoundary = new CompetitionGroupSetBoundary();
@@ -413,11 +304,6 @@ public class ConerDropwizardApplication extends Application<ConerDropwizardConfi
         this.competitionGroupSetBoundary = competitionGroupSetBoundary;
     }
 
-    /**
-     * Lazy initializer for the CompetitionGroupSetDao
-     *
-     * @return the CompetitionGroupSetDao
-     */
     private CompetitionGroupSetDao getCompetitionGroupSetDao() {
         if (competitionGroupSetDao == null) {
             competitionGroupSetDao = new CompetitionGroupSetDao(getHibernate().getSessionFactory());
@@ -429,12 +315,6 @@ public class ConerDropwizardApplication extends Application<ConerDropwizardConfi
         this.competitionGroupSetDao = competitionGroupSetDao;
     }
 
-
-    /**
-     * Lazy initializer for the ConerCoreService.
-     *
-     * @return the ConerCoreService
-     */
     private ConerCoreService getConerCoreService() {
         if (conerCoreService == null) {
             conerCoreService = new ConerCoreService(

--- a/dropwizard-app/src/main/java/org/coner/ConerDropwizardConfiguration.java
+++ b/dropwizard-app/src/main/java/org/coner/ConerDropwizardConfiguration.java
@@ -5,13 +5,9 @@ import io.dropwizard.Configuration;
 import io.dropwizard.client.JerseyClientConfiguration;
 import io.dropwizard.db.DataSourceFactory;
 import io.federecio.dropwizard.swagger.SwaggerBundleConfiguration;
-
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
-/**
- * Coner configuration for Dropwizard Application.
- */
 public class ConerDropwizardConfiguration extends Configuration {
 
     @Valid

--- a/dropwizard-app/src/main/java/org/coner/boundary/AbstractBoundary.java
+++ b/dropwizard-app/src/main/java/org/coner/boundary/AbstractBoundary.java
@@ -1,27 +1,23 @@
 package org.coner.boundary;
 
-import com.google.common.base.Preconditions;
 import org.coner.api.entity.ApiEntity;
 import org.coner.core.domain.DomainEntity;
 import org.coner.hibernate.entity.HibernateEntity;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.List;
+import com.google.common.base.Preconditions;
+import java.lang.reflect.*;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
  * AbstractBoundary provides sensible default behaviors for most boundary traversals, including instantiating
  * an entity, converting a single entity in any supported direction, and converting a list of entities in any
  * supported direction.
- * <p/>
+ * <p>
  * The implementation details of the conversion are left for the concrete implementation in the form of building the
  * required `AbstractBoundary.EntityMerger` instance, which should be returned from concrete implementations of the
  * abstract build*Merger() methods.
- * <p/>
+ * <p>
  * The following conversions are supported:
  * <ul>
  * <li>API to Domain</li>
@@ -29,7 +25,7 @@ import java.util.stream.Collectors;
  * <li>Domain to Hibernate</li>
  * <li>Hibernate to Domain</li>
  * </ul>
- * <p/>
+ * <p>
  * Intentionally absent from this list are "API to Hibernate" and "Hibernate to API".
  *
  * @param <A> the API entity type
@@ -46,9 +42,6 @@ public abstract class AbstractBoundary<A extends ApiEntity, D extends DomainEnti
     private EntityMerger<D, H> domainToHibernateMerger;
     private EntityMerger<H, D> hibernateToDomainMerger;
 
-    /**
-     * Default constructor for the AbstractBoundary.
-     */
     public AbstractBoundary() {
         Type[] typeParameters = ((ParameterizedType) getClass().getGenericSuperclass()).getActualTypeArguments();
         this.apiClass = (Class<A>) typeParameters[0];
@@ -56,11 +49,6 @@ public abstract class AbstractBoundary<A extends ApiEntity, D extends DomainEnti
         this.hibernateClass = (Class<H>) typeParameters[2];
     }
 
-    /**
-     * Get the Domain to API merger (lazy-init).
-     *
-     * @return the Domain to API merger
-     */
     private EntityMerger<D, A> getDomainToApiMerger() {
         if (domainToApiMerger == null) {
             domainToApiMerger = buildDomainToApiMerger();
@@ -68,12 +56,6 @@ public abstract class AbstractBoundary<A extends ApiEntity, D extends DomainEnti
         return domainToApiMerger;
     }
 
-    /**
-     * Convert a Domain entity into an API entity.
-     *
-     * @param domainEntity a Domain entity instance or null
-     * @return an API entity or null if domainEntity is null
-     */
     public A toApiEntity(D domainEntity) {
         if (domainEntity == null) {
             return null;
@@ -83,11 +65,6 @@ public abstract class AbstractBoundary<A extends ApiEntity, D extends DomainEnti
         return apiEntity;
     }
 
-    /**
-     * Get the API to Domain merger (lazy-init).
-     *
-     * @return the API to Domain merger
-     */
     private EntityMerger<A, D> getApiToDomainMerger() {
         if (apiToDomainMerger == null) {
             apiToDomainMerger = buildApiToDomainMerger();
@@ -95,12 +72,6 @@ public abstract class AbstractBoundary<A extends ApiEntity, D extends DomainEnti
         return apiToDomainMerger;
     }
 
-    /**
-     * Convert an API entity into a Domain entity.
-     *
-     * @param apiEntity an API entity instance or null
-     * @return a Domain entity or null if apiEntity is null
-     */
     public D toDomainEntity(A apiEntity) {
         if (apiEntity == null) {
             return null;
@@ -110,11 +81,6 @@ public abstract class AbstractBoundary<A extends ApiEntity, D extends DomainEnti
         return domainEntity;
     }
 
-    /**
-     * Get the Hibernate to Domain merger (lazy-init).
-     *
-     * @return the Hibernate to Domain merger
-     */
     private EntityMerger<H, D> getHibernateToDomainMerger() {
         if (hibernateToDomainMerger == null) {
             hibernateToDomainMerger = buildHibernateToDomainMerger();
@@ -122,12 +88,6 @@ public abstract class AbstractBoundary<A extends ApiEntity, D extends DomainEnti
         return hibernateToDomainMerger;
     }
 
-    /**
-     * Convert a Hibernate entity into a Domain entity.
-     *
-     * @param hibernateEntity a Hibernate entity instance or null
-     * @return a Domain entity or null if hibernateEntity is null
-     */
     public D toDomainEntity(H hibernateEntity) {
         if (hibernateEntity == null) {
             return null;
@@ -137,11 +97,6 @@ public abstract class AbstractBoundary<A extends ApiEntity, D extends DomainEnti
         return domainEntity;
     }
 
-    /**
-     * Get the Domain to Hibernate merger (lazy-init).
-     *
-     * @return the Domain to Hibernate merger
-     */
     private EntityMerger<D, H> getDomainToHibernateMerger() {
         if (domainToHibernateMerger == null) {
             domainToHibernateMerger = buildDomainToHibernateMerger();
@@ -149,12 +104,6 @@ public abstract class AbstractBoundary<A extends ApiEntity, D extends DomainEnti
         return domainToHibernateMerger;
     }
 
-    /**
-     * Convert a Domain entity into a Hibernate entity.
-     *
-     * @param domainEntity a Domain entity instance or null
-     * @return a Hibernate entity or null if domainEntity is null
-     */
     public H toHibernateEntity(D domainEntity) {
         if (domainEntity == null) {
             return null;
@@ -164,19 +113,10 @@ public abstract class AbstractBoundary<A extends ApiEntity, D extends DomainEnti
         return hibernateEntity;
     }
 
-    /**
-     * Convenience to instantiate a class using its default constructor.
-     *
-     * @param clazz the Class of the instance to be instantiated
-     * @param <T>   the type of the instance to instantiate
-     * @return a new instance of the type represented by clazz
-     * @throws java.lang.RuntimeException if an instance cannot be created using the default constructor, such as if
-     *                                    the constructor or class is private
-     */
-    protected <T> T instantiate(Class<T> clazz) {
+    protected <T> T instantiate(Class<T> classToInstantiate) {
         Constructor<T> constructor = null;
         try {
-            constructor = clazz.getConstructor();
+            constructor = classToInstantiate.getConstructor();
             return constructor.newInstance();
         } catch (NoSuchMethodException
                 | InvocationTargetException
@@ -187,12 +127,6 @@ public abstract class AbstractBoundary<A extends ApiEntity, D extends DomainEnti
         }
     }
 
-    /**
-     * Convert a list of API entities into a list of Domain entities.
-     *
-     * @param domainEntities a list of Domain entities or null. The list must not contain any null items.
-     * @return a list of Domain entities or an empty list if domainEntities is null or empty
-     */
     public List<A> toApiEntities(List<D> domainEntities) {
         if (domainEntities == null || domainEntities.isEmpty()) {
             return new ArrayList<>();
@@ -202,12 +136,6 @@ public abstract class AbstractBoundary<A extends ApiEntity, D extends DomainEnti
         return apiEntities;
     }
 
-    /**
-     * Convert a list of Hibernate entities into a list of Domain entities.
-     *
-     * @param hibernateEntities a list of Hibernate entities or null. The list must not contain any null items.
-     * @return a list of Domain entities or an empty list if hibernateEntities is null or empty
-     */
     public List<D> toDomainEntities(List<H> hibernateEntities) {
         if (hibernateEntities == null || hibernateEntities.isEmpty()) {
             return new ArrayList<>();
@@ -217,12 +145,6 @@ public abstract class AbstractBoundary<A extends ApiEntity, D extends DomainEnti
         return domainEntities;
     }
 
-    /**
-     * Convert a list of Domain entities into a list of Hibernate entities.
-     *
-     * @param domainEntities a list of Domain entities or null. The list must not contain any null items.
-     * @return a list of Hibernate entities or an empty list if domainEntities is null or empty
-     */
     public List<H> toHibernateEntities(List<D> domainEntities) {
         if (domainEntities == null || domainEntities.isEmpty()) {
             return new ArrayList<>();
@@ -232,92 +154,36 @@ public abstract class AbstractBoundary<A extends ApiEntity, D extends DomainEnti
         return hibernateEntities;
     }
 
-    /**
-     * Merge an API entity into a Domain entity.
-     * <p/>
-     * Neither argument may be null. If you don't have a Domain entity instance yet, use
-     * `AbstractBoundary.toDomainEntity` instead.
-     *
-     * @param fromApiEntity    the source API entity
-     * @param intoDomainEntity the destination API entity
-     */
     public void merge(A fromApiEntity, D intoDomainEntity) {
         Preconditions.checkNotNull(fromApiEntity);
         Preconditions.checkNotNull(intoDomainEntity);
         getApiToDomainMerger().merge(fromApiEntity, intoDomainEntity);
     }
 
-    /**
-     * Merge a Domain entity into an API entity.
-     * <p/>
-     * Neither argument may be null. If you don't have an API entity instance yet, use
-     * `AbstractBoundary.toDomainEntity` instead.
-     *
-     * @param fromDomainEntity the source Domain entity
-     * @param intoApiEntity    the destination API entity
-     */
     public void merge(D fromDomainEntity, A intoApiEntity) {
         Preconditions.checkNotNull(fromDomainEntity);
         Preconditions.checkNotNull(intoApiEntity);
         getDomainToApiMerger().merge(fromDomainEntity, intoApiEntity);
     }
 
-    /**
-     * Merge a Domain entity into a Hibernate entity.
-     * <p/>
-     * Neither argument may be null. If you don't have a Hibernate entity instance yet, use
-     * `AbstractBoundary.toHibernateEntity` instead.
-     *
-     * @param fromDomainEntity    the source Domain entity
-     * @param intoHibernateEntity the destination Hibernate entity
-     */
     public void merge(D fromDomainEntity, H intoHibernateEntity) {
         Preconditions.checkNotNull(fromDomainEntity);
         Preconditions.checkNotNull(intoHibernateEntity);
         getDomainToHibernateMerger().merge(fromDomainEntity, intoHibernateEntity);
     }
 
-    /**
-     * Merge a Hibernate entity into a Domain entity.
-     * <p/>
-     * Neither argument may be null. If you don't have a Domain entity instance yet, use
-     * `AbstractBoundary.toDomainEntity` instead.
-     *
-     * @param fromHibernateEntity the source Hibernate entity
-     * @param intoDomainEntity    the destination Domain entity
-     */
     public void merge(H fromHibernateEntity, D intoDomainEntity) {
         Preconditions.checkNotNull(fromHibernateEntity);
         Preconditions.checkNotNull(intoDomainEntity);
         getHibernateToDomainMerger().merge(fromHibernateEntity, intoDomainEntity);
     }
 
-    /**
-     * Build an EntityMerger to merge an API entity into a Domain Entity.
-     *
-     * @return an EntityMerger to merge an API entity into a Domain Entity
-     */
     protected abstract EntityMerger<A, D> buildApiToDomainMerger();
 
-    /**
-     * Build an EntityMerger to merge a Domain entity into an API entity.
-     *
-     * @return an EntityMerger to merge a Domain entity into an API entity
-     */
     protected abstract EntityMerger<D, A> buildDomainToApiMerger();
 
-    /**
-     * Build an EntityMerger to merge a Domain entity into a Hibernate entity.
-     *
-     * @return an EntityMerger to merge a Domain entity into a Hibernate entity
-     */
     protected abstract EntityMerger<D, H> buildDomainToHibernateMerger();
 
-    /**
-     * Build an EntityMerger to merge a Hibernate entity into a Domain entity.
-     *
-     * @return an EntityMerger to merge a Hibernate entity into a Domain entity
-     */
     protected abstract EntityMerger<H, D> buildHibernateToDomainMerger();
 
 }

--- a/dropwizard-app/src/main/java/org/coner/boundary/CompetitionGroupBoundary.java
+++ b/dropwizard-app/src/main/java/org/coner/boundary/CompetitionGroupBoundary.java
@@ -2,9 +2,6 @@ package org.coner.boundary;
 
 import org.coner.core.domain.CompetitionGroup;
 
-/**
- * Converts CompetitionGroup entities as they cross architectural boundaries.
- */
 public class CompetitionGroupBoundary extends AbstractBoundary<
         org.coner.api.entity.CompetitionGroup,
         CompetitionGroup,

--- a/dropwizard-app/src/main/java/org/coner/boundary/CompetitionGroupSetBoundary.java
+++ b/dropwizard-app/src/main/java/org/coner/boundary/CompetitionGroupSetBoundary.java
@@ -3,9 +3,6 @@ package org.coner.boundary;
 import org.coner.api.request.AddCompetitionGroupSetRequest;
 import org.coner.core.domain.CompetitionGroupSet;
 
-/**
- * Converts CompetitionGroupSet entities as they cross architectural boundaries
- */
 public class CompetitionGroupSetBoundary extends AbstractBoundary<
         org.coner.api.entity.CompetitionGroupSet,
         CompetitionGroupSet,
@@ -20,12 +17,6 @@ public class CompetitionGroupSetBoundary extends AbstractBoundary<
         return new ReflectionEntityMerger<>();
     }
 
-    /**
-     * Convert an API AddCompetitionGroupSetRequest to a domain CompetitionGroupSet
-     *
-     * @param addCompetitionGroupSetRequest the API request to convert
-     * @return a CompetitionGroupSet entity
-     */
     public CompetitionGroupSet toDomainEntity(AddCompetitionGroupSetRequest addCompetitionGroupSetRequest) {
         if (apiAddCompetitionGroupSetRequestToDomainCompetitionGroupSetEntityMerger == null) {
             apiAddCompetitionGroupSetRequestToDomainCompetitionGroupSetEntityMerger = new ReflectionEntityMerger<>();

--- a/dropwizard-app/src/main/java/org/coner/boundary/EventBoundary.java
+++ b/dropwizard-app/src/main/java/org/coner/boundary/EventBoundary.java
@@ -2,9 +2,6 @@ package org.coner.boundary;
 
 import org.coner.core.domain.Event;
 
-/**
- * Converts Event entities as they cross architectural boundaries.
- */
 public class EventBoundary extends AbstractBoundary<
         org.coner.api.entity.Event,
         Event,

--- a/dropwizard-app/src/main/java/org/coner/boundary/HandicapGroupBoundary.java
+++ b/dropwizard-app/src/main/java/org/coner/boundary/HandicapGroupBoundary.java
@@ -2,9 +2,6 @@ package org.coner.boundary;
 
 import org.coner.core.domain.HandicapGroup;
 
-/**
- * Converts HandicapGroup entities as they cross architectural boundaries.
- */
 public class HandicapGroupBoundary extends AbstractBoundary<
         org.coner.api.entity.HandicapGroup,
         HandicapGroup,

--- a/dropwizard-app/src/main/java/org/coner/boundary/ReflectionEntityMerger.java
+++ b/dropwizard-app/src/main/java/org/coner/boundary/ReflectionEntityMerger.java
@@ -2,15 +2,12 @@ package org.coner.boundary;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
-
-import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
+import java.lang.reflect.*;
 import java.util.HashMap;
 
 /**
  * ReflectionEntityMerger uses reflection to automatically merge entities that follow the JavaBean convention.
- * <p/>
+ * <p>
  * Only the destination entity's setters which correspond to the source entity's getters will be called. Only the
  * getters/setters which correspond to like-named properties will be used. Strings corresponding to Enum names will be
  * transformed automatically.

--- a/dropwizard-app/src/main/java/org/coner/boundary/RegistrationBoundary.java
+++ b/dropwizard-app/src/main/java/org/coner/boundary/RegistrationBoundary.java
@@ -2,9 +2,6 @@ package org.coner.boundary;
 
 import org.coner.core.domain.Registration;
 
-/**
- * Converts Registration entities as they cross architectural boundaries.
- */
 public class RegistrationBoundary extends AbstractBoundary<
         org.coner.api.entity.Registration,
         Registration,
@@ -12,11 +9,6 @@ public class RegistrationBoundary extends AbstractBoundary<
 
     private final EventBoundary eventBoundary;
 
-    /**
-     * Public constructor for the RegistrationBoundary.
-     *
-     * @param eventBoundary the EventBoundary to use when converting Event entities
-     */
     public RegistrationBoundary(EventBoundary eventBoundary) {
         super();
         this.eventBoundary = eventBoundary;

--- a/dropwizard-app/src/main/java/org/coner/core/ConerCoreService.java
+++ b/dropwizard-app/src/main/java/org/coner/core/ConerCoreService.java
@@ -1,24 +1,12 @@
 package org.coner.core;
 
-import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
-import org.coner.core.domain.CompetitionGroup;
-import org.coner.core.domain.CompetitionGroupSet;
-import org.coner.core.domain.Event;
-import org.coner.core.domain.HandicapGroup;
-import org.coner.core.domain.Registration;
+import org.coner.core.domain.*;
 import org.coner.core.exception.EventRegistrationMismatchException;
-import org.coner.core.gateway.CompetitionGroupGateway;
-import org.coner.core.gateway.CompetitionGroupSetGateway;
-import org.coner.core.gateway.EventGateway;
-import org.coner.core.gateway.HandicapGroupGateway;
-import org.coner.core.gateway.RegistrationGateway;
+import org.coner.core.gateway.*;
 
+import com.google.common.base.*;
 import java.util.List;
 
-/**
- * The ConerCoreService is the domain level implementation of all functionality in the Coner core project.
- */
 public class ConerCoreService {
 
     private final EventGateway eventGateway;
@@ -27,15 +15,6 @@ public class ConerCoreService {
     private final CompetitionGroupSetGateway competitionGroupSetGateway;
     private final HandicapGroupGateway handicapGroupGateway;
 
-    /**
-     * Constructor for ConerCoreService.
-     *
-     * @param eventGateway               the EventGateway
-     * @param registrationGateway        the RegistrationGateway
-     * @param competitionGroupGateway    the CompetitionGroupGateway
-     * @param competitionGroupSetGateway the CompetitionGroupSetGateway
-     * @param handicapGroupGateway       the HandicapGroupGateway
-     */
     public ConerCoreService(EventGateway eventGateway,
                             RegistrationGateway registrationGateway,
                             CompetitionGroupGateway competitionGroupGateway,
@@ -49,45 +28,20 @@ public class ConerCoreService {
         this.competitionGroupGateway = competitionGroupGateway;
     }
 
-    /**
-     * Get all events.
-     *
-     * @return a list of all events
-     */
     public List<Event> getEvents() {
         return eventGateway.getAll();
     }
 
-    /**
-     * Add an event.
-     *
-     * @param event the Event entity to add
-     */
     public void addEvent(Event event) {
         Preconditions.checkNotNull(event);
         eventGateway.create(event);
     }
 
-    /**
-     * Get an Event by id.
-     *
-     * @param id the id of the event
-     * @return the event with id or null if not found
-     */
     public Event getEvent(String id) {
         Preconditions.checkArgument(!Strings.isNullOrEmpty(id));
         return eventGateway.findById(id);
     }
 
-    /**
-     * Get a Registration by id.
-     *
-     * @param eventId        the id of the Event the Registration belongs to
-     * @param registrationId the id of the Registration
-     * @return the Registration with id or null if not found
-     * @throws org.coner.core.exception.EventRegistrationMismatchException if the Registration's Event id doesn't match
-     *                                                                     eventId
-     */
     public Registration getRegistration(String eventId, String registrationId)
             throws EventRegistrationMismatchException {
         Preconditions.checkArgument(!Strings.isNullOrEmpty(eventId));
@@ -106,12 +60,6 @@ public class ConerCoreService {
         return registration;
     }
 
-    /**
-     * Add a registration entry.
-     *
-     * @param event        the Event the Registration is being added for
-     * @param registration the Registration to add
-     */
     public void addRegistration(Event event, Registration registration) {
         Preconditions.checkNotNull(registration);
         Preconditions.checkNotNull(event);
@@ -119,82 +67,39 @@ public class ConerCoreService {
         registrationGateway.create(registration);
     }
 
-    /**
-     * Get all registrations for an event.
-     *
-     * @param event the event to get registrations
-     * @return a list of all registrations for the event
-     */
     public List<Registration> getRegistrations(Event event) {
         Preconditions.checkNotNull(event);
         return registrationGateway.getAllWith(event);
     }
 
-    /**
-     * Add a competition group.
-     *
-     * @param competitionGroup the Event entity to add
-     */
     public void addCompetitionGroup(CompetitionGroup competitionGroup) {
         Preconditions.checkNotNull(competitionGroup);
         competitionGroupGateway.create(competitionGroup);
     }
 
-    /**
-     * Get all CompetitionGroups.
-     *
-     * @return a List of CompetitionGroup entities.
-     */
     public List<CompetitionGroup> getCompetitionGroups() {
         return competitionGroupGateway.getAll();
     }
 
-    /**
-     * Get a CompetitionGroup by id.
-     *
-     * @param id the id of the CompetitionGroup
-     * @return the CompetitionGroup with id or null if not found
-     */
     public CompetitionGroup getCompetitionGroup(String id) {
         Preconditions.checkArgument(!Strings.isNullOrEmpty(id));
         return competitionGroupGateway.findById(id);
     }
 
-    /**
-     * Add a CompetitionGroupSet
-     *
-     * @param competitionGroupSet the CompetitionGroupSet entity to add
-     */
     public void addCompetitionGroupSet(CompetitionGroupSet competitionGroupSet) {
         Preconditions.checkNotNull(competitionGroupSet);
         competitionGroupSetGateway.create(competitionGroupSet);
     }
 
-    /**
-     * Add a HandicapGroup.
-     *
-     * @param handicapGroup the HandicapGroup entity to add
-     */
     public void addHandicapGroup(HandicapGroup handicapGroup) {
         Preconditions.checkNotNull(handicapGroup);
         handicapGroupGateway.create(handicapGroup);
     }
 
-    /**
-     * Get all HandicapGroups.
-     *
-     * @return a List of HandicapGroup.
-     */
     public List<HandicapGroup> getHandicapGroups() {
         return handicapGroupGateway.getAll();
     }
 
-    /**
-     * Get a HandicapGroup by id.
-     *
-     * @param id the id of the HandicapGroup
-     * @return the HandicapGroup with id or null if not found
-     */
     public HandicapGroup getHandicapGroup(String id) {
         Preconditions.checkArgument(!Strings.isNullOrEmpty(id));
         return handicapGroupGateway.findById(id);

--- a/dropwizard-app/src/main/java/org/coner/core/domain/Event.java
+++ b/dropwizard-app/src/main/java/org/coner/core/domain/Event.java
@@ -2,9 +2,6 @@ package org.coner.core.domain;
 
 import java.util.Date;
 
-/**
- * Domain entity for the representation of Events.
- */
 public class Event extends DomainEntity {
 
     private String id;
@@ -35,10 +32,6 @@ public class Event extends DomainEntity {
         this.date = date;
     }
 
-    /**
-     * Does Event have a date?
-     * @return true if this Event has a date
-     */
     public boolean hasDate() {
         return date != null;
     }

--- a/dropwizard-app/src/main/java/org/coner/core/exception/package-info.java
+++ b/dropwizard-app/src/main/java/org/coner/core/exception/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Contains Exception classes which should only be thrown by org.coner.core (sub-)package classes.
+ */
+package org.coner.core.exception;

--- a/dropwizard-app/src/main/java/org/coner/core/gateway/CompetitionGroupGateway.java
+++ b/dropwizard-app/src/main/java/org/coner/core/gateway/CompetitionGroupGateway.java
@@ -1,28 +1,17 @@
 package org.coner.core.gateway;
 
-import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
 import org.coner.boundary.CompetitionGroupBoundary;
 import org.coner.core.domain.CompetitionGroup;
 import org.coner.hibernate.dao.CompetitionGroupDao;
 
+import com.google.common.base.*;
 import java.util.List;
 
-/**
- * CompetitionGroupGateway wraps persistence layer interactions for CompetitionGroup domain entities.
- */
 public class CompetitionGroupGateway {
 
     private final CompetitionGroupBoundary competitionGroupBoundary;
     private final CompetitionGroupDao competitionGroupDao;
 
-    /**
-     * Constructor for CompetitionGroupGateway.
-     *
-     * @param competitionGroupBoundary the CompetitionGroupBoundary for converting Domain entities to/from Hibernate
-     *                                 entities
-     * @param competitionGroupDao      the CompetitionGroupDao for interacting with the persistence layer
-     */
     public CompetitionGroupGateway(
             CompetitionGroupBoundary competitionGroupBoundary,
             CompetitionGroupDao competitionGroupDao
@@ -31,11 +20,6 @@ public class CompetitionGroupGateway {
         this.competitionGroupDao = competitionGroupDao;
     }
 
-    /**
-     * Create a new CompetitionGroup entity.
-     *
-     * @param competitionGroup the CompetitionGroup to create
-     */
     public void create(CompetitionGroup competitionGroup) {
         Preconditions.checkNotNull(competitionGroup);
         org.coner.hibernate.entity.CompetitionGroup hCompetitionGroup = competitionGroupBoundary.toHibernateEntity(
@@ -45,22 +29,11 @@ public class CompetitionGroupGateway {
         competitionGroupBoundary.merge(hCompetitionGroup, competitionGroup);
     }
 
-    /**
-     * Get all CompetitionGroup entities.
-     *
-     * @return list of CompetitionGroup entities
-     */
     public List<CompetitionGroup> getAll() {
         List<org.coner.hibernate.entity.CompetitionGroup> competitionGroups = competitionGroupDao.findAll();
         return competitionGroupBoundary.toDomainEntities(competitionGroups);
     }
 
-    /**
-     * Get a CompetitionGroup entity by id.
-     *
-     * @param competitionGroupId id of the CompetitionGroup
-     * @return the CompetitionGroup entity with id or null if not found
-     */
     public CompetitionGroup findById(String competitionGroupId) {
         Preconditions.checkArgument(!Strings.isNullOrEmpty(competitionGroupId));
         org.coner.hibernate.entity.CompetitionGroup hibernateCompetitionGroup = competitionGroupDao.findById(

--- a/dropwizard-app/src/main/java/org/coner/core/gateway/CompetitionGroupSetGateway.java
+++ b/dropwizard-app/src/main/java/org/coner/core/gateway/CompetitionGroupSetGateway.java
@@ -1,25 +1,16 @@
 package org.coner.core.gateway;
 
-import com.google.common.base.Preconditions;
 import org.coner.boundary.CompetitionGroupSetBoundary;
 import org.coner.core.domain.CompetitionGroupSet;
 import org.coner.hibernate.dao.CompetitionGroupSetDao;
 
-/**
- * CompetitionGroupSetGateway wraps persistence layer interactions for CompetitionGroupSet domain entities.
- */
+import com.google.common.base.Preconditions;
+
 public class CompetitionGroupSetGateway {
 
     private final CompetitionGroupSetBoundary competitionGroupSetBoundary;
     private final CompetitionGroupSetDao competitionGroupSetDao;
 
-    /**
-     * Constructor for CompetitionGroupSetGateway
-     *
-     * @param competitionGroupSetBoundary the CompetitionGroupSetBoundary for converting domain CompetitionGroupSet
-     *                                    entities to/from Hibernate entities
-     * @param competitionGroupSetDao      the CompetitionGroupSetDao for interacting with the persistence  layer
-     */
     public CompetitionGroupSetGateway(
             CompetitionGroupSetBoundary competitionGroupSetBoundary,
             CompetitionGroupSetDao competitionGroupSetDao
@@ -28,11 +19,6 @@ public class CompetitionGroupSetGateway {
         this.competitionGroupSetDao = competitionGroupSetDao;
     }
 
-    /**
-     * Create a new CompetitionGroupSet entity
-     *
-     * @param competitionGroupSet the CompetitionGroupSet entity to create
-     */
     public void create(CompetitionGroupSet competitionGroupSet) {
         Preconditions.checkNotNull(competitionGroupSet);
         org.coner.hibernate.entity.CompetitionGroupSet hCompetitionGroupSet = competitionGroupSetBoundary

--- a/dropwizard-app/src/main/java/org/coner/core/gateway/EventGateway.java
+++ b/dropwizard-app/src/main/java/org/coner/core/gateway/EventGateway.java
@@ -1,59 +1,33 @@
 package org.coner.core.gateway;
 
-import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
 import org.coner.boundary.EventBoundary;
 import org.coner.core.domain.Event;
 import org.coner.hibernate.dao.EventDao;
 
+import com.google.common.base.*;
 import java.util.List;
 
-/**
- * EventGateway wraps persistence layer interactions for Event domain entities.
- */
 public class EventGateway {
 
     private final EventBoundary eventBoundary;
     private final EventDao eventDao;
 
-    /**
-     * Constructor for EventGateway.
-     *
-     * @param eventBoundary the EventBoundary for converting Domain entities to/from Hibernate entities
-     * @param eventDao      the EventDao for interacting with the persistence layer
-     */
     public EventGateway(EventBoundary eventBoundary, EventDao eventDao) {
         this.eventBoundary = eventBoundary;
         this.eventDao = eventDao;
     }
 
-    /**
-     * Get all Event entities.
-     *
-     * @return a list of all Event entities
-     */
     public List<Event> getAll() {
         List<org.coner.hibernate.entity.Event> events = eventDao.findAll();
         return eventBoundary.toDomainEntities(events);
     }
 
-    /**
-     * Get an Event entity by id.
-     *
-     * @param eventId eventId of the Event
-     * @return the Event entity with id or null if not found
-     */
     public Event findById(String eventId) {
         Preconditions.checkArgument(!Strings.isNullOrEmpty(eventId));
         org.coner.hibernate.entity.Event hibernateEvent = eventDao.findById(eventId);
         return eventBoundary.toDomainEntity(hibernateEvent);
     }
 
-    /**
-     * Persist a new Event entity.
-     *
-     * @param event the Event entity to persist
-     */
     public void create(Event event) {
         Preconditions.checkNotNull(event);
         org.coner.hibernate.entity.Event hibernateEvent = eventBoundary.toHibernateEntity(event);

--- a/dropwizard-app/src/main/java/org/coner/core/gateway/HandicapGroupGateway.java
+++ b/dropwizard-app/src/main/java/org/coner/core/gateway/HandicapGroupGateway.java
@@ -1,37 +1,22 @@
 package org.coner.core.gateway;
 
-import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
 import org.coner.boundary.HandicapGroupBoundary;
 import org.coner.core.domain.HandicapGroup;
 import org.coner.hibernate.dao.HandicapGroupDao;
 
+import com.google.common.base.*;
 import java.util.List;
 
-/**
- * HandicapGroupGateway wraps persistence layer interactions for HandicapGroup domain entities.
- */
 public class HandicapGroupGateway {
 
     private final HandicapGroupBoundary handicapGroupBoundary;
     private final HandicapGroupDao handicapGroupDao;
 
-    /**
-     * Constructor for HandicapGroupGateway.
-     *
-     * @param handicapGroupBoundary the HandicapGroupBoundary for converting Domain entities to/from Hibernate entities
-     * @param handicapGroupDao      the HandicapGroupDao for interacting with the persistence layer
-     */
     public HandicapGroupGateway(HandicapGroupBoundary handicapGroupBoundary, HandicapGroupDao handicapGroupDao) {
         this.handicapGroupBoundary = handicapGroupBoundary;
         this.handicapGroupDao = handicapGroupDao;
     }
 
-    /**
-     * Persist a new HandicapGroup entity.
-     *
-     * @param handicapGroup the HandicapGroup entity to persist
-     */
     public void create(HandicapGroup handicapGroup) {
         Preconditions.checkNotNull(handicapGroup);
         org.coner.hibernate.entity.HandicapGroup hibernateHandicapGroup =
@@ -40,22 +25,11 @@ public class HandicapGroupGateway {
         handicapGroupBoundary.merge(hibernateHandicapGroup, handicapGroup);
     }
 
-    /**
-     * Get all HandicapGroup entities.
-     *
-     * @return list of HandicapGroup entities
-     */
     public List<HandicapGroup> getAll() {
         List<org.coner.hibernate.entity.HandicapGroup> handicapGroups = handicapGroupDao.findAll();
         return handicapGroupBoundary.toDomainEntities(handicapGroups);
     }
 
-    /**
-     * Get a HandicapGroup entity by id.
-     *
-     * @param handicapGroupId id of the HandicapGroup
-     * @return the HandicapGroup entity with id or null if not found
-     */
     public HandicapGroup findById(String handicapGroupId) {
         Preconditions.checkArgument(!Strings.isNullOrEmpty(handicapGroupId));
         org.coner.hibernate.entity.HandicapGroup hibernateHandicapGroup = handicapGroupDao.findById(handicapGroupId);

--- a/dropwizard-app/src/main/java/org/coner/core/gateway/RegistrationGateway.java
+++ b/dropwizard-app/src/main/java/org/coner/core/gateway/RegistrationGateway.java
@@ -1,31 +1,18 @@
 package org.coner.core.gateway;
 
-import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
-import org.coner.boundary.EventBoundary;
-import org.coner.boundary.RegistrationBoundary;
-import org.coner.core.domain.Event;
-import org.coner.core.domain.Registration;
+import org.coner.boundary.*;
+import org.coner.core.domain.*;
 import org.coner.hibernate.dao.RegistrationDao;
 
+import com.google.common.base.*;
 import java.util.List;
 
-/**
- * RegistrationGateway wraps persistence layer interactions for Registration domain entities.
- */
 public class RegistrationGateway {
 
     private final RegistrationBoundary registrationBoundary;
     private final EventBoundary eventBoundary;
     private final RegistrationDao registrationDao;
 
-    /**
-     * Constructor for RegistrationGateway.
-     *
-     * @param registrationBoundary the RegistrationBoundary for converting Domain entities to/from Hibernate entities
-     * @param eventBoundary        the EventBoundary for converting Domain entities to/from Hibernate entities
-     * @param registrationDao      the RegistrationDao for interacting with the persistence layer
-     */
     public RegistrationGateway(
             RegistrationBoundary registrationBoundary,
             EventBoundary eventBoundary,
@@ -35,24 +22,12 @@ public class RegistrationGateway {
         this.registrationDao = registrationDao;
     }
 
-    /**
-     * Get a Registration entity by id.
-     *
-     * @param registrationId eventId of the Registration
-     * @return the Registration entity with id or null if not found
-     */
     public Registration findById(String registrationId) {
         Preconditions.checkArgument(!Strings.isNullOrEmpty(registrationId));
         org.coner.hibernate.entity.Registration hibernateRegistration = registrationDao.findById(registrationId);
         return registrationBoundary.toDomainEntity(hibernateRegistration);
     }
 
-    /**
-     * Get list of Registrations for a given Event.
-     *
-     * @param event event to find Registrations for
-     * @return List of Registrations for Event
-     */
     public List<Registration> getAllWith(Event event) {
         Preconditions.checkNotNull(event);
         org.coner.hibernate.entity.Event hibernateEvent = eventBoundary.toHibernateEntity(event);
@@ -60,11 +35,6 @@ public class RegistrationGateway {
         return registrationBoundary.toDomainEntities(registrations);
     }
 
-    /**
-     * Persist a new Registration entity.
-     *
-     * @param registration Registration to create
-     */
     public void create(Registration registration) {
         Preconditions.checkNotNull(registration);
         org.coner.hibernate.entity.Registration hibernateRegistration =

--- a/dropwizard-app/src/main/java/org/coner/exception/WebApplicationExceptionMapper.java
+++ b/dropwizard-app/src/main/java/org/coner/exception/WebApplicationExceptionMapper.java
@@ -1,17 +1,13 @@
 package org.coner.exception;
 
-import com.google.common.base.Strings;
 import org.coner.api.response.ErrorsResponse;
 
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
+import com.google.common.base.Strings;
 import java.util.Arrays;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.*;
+import javax.ws.rs.ext.ExceptionMapper;
 
-/**
- * Class for mapping Web Application Exceptions and create appropriate responses.
- */
 public class WebApplicationExceptionMapper implements ExceptionMapper<WebApplicationException> {
     @Override
     public Response toResponse(WebApplicationException e) {

--- a/dropwizard-app/src/main/java/org/coner/hibernate/dao/CompetitionGroupDao.java
+++ b/dropwizard-app/src/main/java/org/coner/hibernate/dao/CompetitionGroupDao.java
@@ -1,49 +1,25 @@
 package org.coner.hibernate.dao;
 
-import io.dropwizard.hibernate.AbstractDAO;
 import org.coner.hibernate.entity.CompetitionGroup;
+
+import io.dropwizard.hibernate.AbstractDAO;
+import java.util.List;
 import org.hibernate.SessionFactory;
 
-import java.util.List;
-
-/**
- * CompetitionGroup-specific Hibernate Data Access Object.
- */
 public class CompetitionGroupDao extends AbstractDAO<CompetitionGroup> {
 
-    /**
-     * Creates a new DAO with a given session provider.
-     *
-     * @param sessionFactory a session provider
-     */
     public CompetitionGroupDao(SessionFactory sessionFactory) {
         super(sessionFactory);
     }
 
-    /**
-     * Save the passed CompetitionGroup in storage.
-     *
-     * @param competitionGroup the CompetitionGroup to save or update
-     */
     public void createOrUpdate(CompetitionGroup competitionGroup) {
         persist(competitionGroup);
     }
 
-    /**
-     * Find all CompetitionGroup entities persisted in storage.
-     *
-     * @return a list of all CompetitionGroup entities
-     */
     public List<CompetitionGroup> findAll() {
         return list(namedQuery(CompetitionGroup.QUERY_FIND_ALL));
     }
 
-    /**
-     * Find a CompetitionGroup by id.
-     *
-     * @param id the id of the CompetitionGroup to find
-     * @return the CompetitionGroup having the id or null if not found
-     */
     public CompetitionGroup findById(String id) {
         return get(id);
     }

--- a/dropwizard-app/src/main/java/org/coner/hibernate/dao/CompetitionGroupSetDao.java
+++ b/dropwizard-app/src/main/java/org/coner/hibernate/dao/CompetitionGroupSetDao.java
@@ -1,28 +1,16 @@
 package org.coner.hibernate.dao;
 
-import io.dropwizard.hibernate.AbstractDAO;
 import org.coner.hibernate.entity.CompetitionGroupSet;
+
+import io.dropwizard.hibernate.AbstractDAO;
 import org.hibernate.SessionFactory;
 
-/**
- * CompetitionGroupSet-specific Hibernate Data Access Object.
- */
 public class CompetitionGroupSetDao extends AbstractDAO<CompetitionGroupSet> {
 
-    /**
-     * Creates a new DAO with a given session provider.
-     *
-     * @param sessionFactory a session provider
-     */
     public CompetitionGroupSetDao(SessionFactory sessionFactory) {
         super(sessionFactory);
     }
 
-    /**
-     * Save the passed CompetitionGroupSet in storage.
-     *
-     * @param competitionGroupSet the CompetitionGroupSet to save or update
-     */
     public void createOrUpdate(CompetitionGroupSet competitionGroupSet) {
         persist(competitionGroupSet);
     }

--- a/dropwizard-app/src/main/java/org/coner/hibernate/dao/EventDao.java
+++ b/dropwizard-app/src/main/java/org/coner/hibernate/dao/EventDao.java
@@ -1,49 +1,26 @@
 package org.coner.hibernate.dao;
 
-import io.dropwizard.hibernate.AbstractDAO;
 import org.coner.hibernate.entity.Event;
+
+import io.dropwizard.hibernate.AbstractDAO;
+import java.util.List;
 import org.hibernate.SessionFactory;
 
-import java.util.List;
-
-/**
- * Event-specific Hibernate Data Access Object.
- */
 public class EventDao extends AbstractDAO<Event> {
 
-    /**
-     * Constructor for EventDao.
-     *
-     * @param sessionFactory the `SessionFactory`
-     */
+
     public EventDao(SessionFactory sessionFactory) {
         super(sessionFactory);
     }
 
-    /**
-     * Find an Event by id.
-     *
-     * @param id the id of the Event to find
-     * @return the Event having `id` or null if not found
-     */
     public Event findById(String id) {
         return get(id);
     }
 
-    /**
-     * Find all Event entities persisted in storage.
-     *
-     * @return a list of all Event entities
-     */
     public List<Event> findAll() {
         return list(namedQuery(Event.QUERY_FIND_ALL));
     }
 
-    /**
-     * Save or update the passed Event in storage.
-     *
-     * @param event the Event to save or update
-     */
     public void create(Event event) {
         persist(event);
     }

--- a/dropwizard-app/src/main/java/org/coner/hibernate/dao/HandicapGroupDao.java
+++ b/dropwizard-app/src/main/java/org/coner/hibernate/dao/HandicapGroupDao.java
@@ -1,49 +1,25 @@
 package org.coner.hibernate.dao;
 
-import io.dropwizard.hibernate.AbstractDAO;
 import org.coner.hibernate.entity.HandicapGroup;
+
+import io.dropwizard.hibernate.AbstractDAO;
+import java.util.List;
 import org.hibernate.SessionFactory;
 
-import java.util.List;
-
-/**
- * HandicapGroup-specific Hibernate Data Access Object.
- */
 public class HandicapGroupDao extends AbstractDAO<HandicapGroup> {
 
-    /**
-     * Constructor for HandicapGroupDao.
-     *
-     * @param sessionFactory the `SessionFactory`
-     */
     public HandicapGroupDao(SessionFactory sessionFactory) {
         super(sessionFactory);
     }
 
-    /**
-     * Save or update the passed HandicapGroup in storage.
-     *
-     * @param handicapGroup the HandicapGroup to save or update
-     */
     public void create(HandicapGroup handicapGroup) {
         persist(handicapGroup);
     }
 
-    /**
-     * Find all HandicapGroup entities persisted in storage.
-     *
-     * @return a list of all HandicapGroup entities
-     */
     public List<HandicapGroup> findAll() {
         return list(namedQuery(HandicapGroup.QUERY_FIND_ALL));
     }
 
-    /**
-     * Find a HandicapGroup by id.
-     *
-     * @param id the id of the HandicapGroup to find
-     * @return the HandicapGroup having the id or null if not found
-     */
     public HandicapGroup findById(String id) {
         return get(id);
     }

--- a/dropwizard-app/src/main/java/org/coner/hibernate/dao/RegistrationDao.java
+++ b/dropwizard-app/src/main/java/org/coner/hibernate/dao/RegistrationDao.java
@@ -1,54 +1,27 @@
 package org.coner.hibernate.dao;
 
+import org.coner.hibernate.entity.*;
+
 import io.dropwizard.hibernate.AbstractDAO;
-import org.coner.hibernate.entity.Event;
-import org.coner.hibernate.entity.Registration;
-import org.hibernate.Query;
-import org.hibernate.SessionFactory;
-
 import java.util.List;
+import org.hibernate.*;
 
-/**
- * Registration-specific Hibernate Data Access Object.
- */
 public class RegistrationDao extends AbstractDAO<Registration> {
 
-    /**
-     * Constructor for RegistrationDao.
-     *
-     * @param sessionFactory the `SessionFactory`
-     */
     public RegistrationDao(SessionFactory sessionFactory) {
         super(sessionFactory);
     }
 
-    /**
-     * Find a Registration by id.
-     *
-     * @param id the id of the Registration to find
-     * @return the Registration having `id` or null if not found
-     */
     public Registration findById(String id) {
         return get(id);
     }
 
-    /**
-     * Find all Registration entities persisted in storage for the Event.
-     *
-     * @param event the Event of all Registrations to search
-     * @return a list of all Registration entities
-     */
     public List<Registration> getAllWith(Event event) {
         Query query = namedQuery(Registration.QUERY_FIND_ALL_WITH_EVENT);
         query.setParameter(Registration.PARAMETER_EVENT_ID, event.getId());
         return list(query);
     }
 
-    /**
-     * Save or update the passed Registration in storage.
-     *
-     * @param registration the Registration to save or update
-     */
     public void create(Registration registration) {
         persist(registration);
     }

--- a/dropwizard-app/src/main/java/org/coner/hibernate/entity/CompetitionGroup.java
+++ b/dropwizard-app/src/main/java/org/coner/hibernate/entity/CompetitionGroup.java
@@ -1,25 +1,10 @@
 package org.coner.hibernate.entity;
 
-import org.hibernate.annotations.GenericGenerator;
-
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.JoinTable;
-import javax.persistence.ManyToMany;
-import javax.persistence.NamedQueries;
-import javax.persistence.NamedQuery;
-import javax.persistence.Table;
 import java.math.BigDecimal;
 import java.util.Set;
+import javax.persistence.*;
+import org.hibernate.annotations.GenericGenerator;
 
-/**
- * Hibernate entity for the persistence of CompetitionGroups.
- */
 @Entity
 @Table(name = "competition_groups")
 @NamedQueries({

--- a/dropwizard-app/src/main/java/org/coner/hibernate/entity/CompetitionGroupSet.java
+++ b/dropwizard-app/src/main/java/org/coner/hibernate/entity/CompetitionGroupSet.java
@@ -1,19 +1,9 @@
 package org.coner.hibernate.entity;
 
+import java.util.Set;
+import javax.persistence.*;
 import org.hibernate.annotations.GenericGenerator;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.ManyToMany;
-import javax.persistence.Table;
-import java.util.Set;
-
-/**
- * Hibernate entity for the persistence of CompetitionGroupSets
- */
 @Entity
 @Table(name = "competition_group_sets")
 public class CompetitionGroupSet extends HibernateEntity {

--- a/dropwizard-app/src/main/java/org/coner/hibernate/entity/Event.java
+++ b/dropwizard-app/src/main/java/org/coner/hibernate/entity/Event.java
@@ -1,22 +1,9 @@
 package org.coner.hibernate.entity;
 
+import java.util.Date;
+import javax.persistence.*;
 import org.hibernate.annotations.GenericGenerator;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.NamedQuery;
-import javax.persistence.Table;
-import javax.persistence.NamedQueries;
-import javax.persistence.Id;
-import javax.persistence.Temporal;
-import javax.persistence.TemporalType;
-
-import java.util.Date;
-
-/**
- * Hibernate entity for the persistence of Events.
- */
 @Entity
 @Table(name = "events")
 @NamedQueries({
@@ -27,11 +14,10 @@ import java.util.Date;
 })
 public class Event extends HibernateEntity {
 
+    public static final String QUERY_FIND_ALL = "org.coner.hibernate.entity.Event.findAll";
     private String id;
     private String name;
     private Date date;
-
-    public static final String QUERY_FIND_ALL = "org.coner.hibernate.entity.Event.findAll";
 
     @Id
     @GeneratedValue(generator = "uuid")

--- a/dropwizard-app/src/main/java/org/coner/hibernate/entity/HandicapGroup.java
+++ b/dropwizard-app/src/main/java/org/coner/hibernate/entity/HandicapGroup.java
@@ -1,19 +1,9 @@
 package org.coner.hibernate.entity;
 
+import java.math.BigDecimal;
+import javax.persistence.*;
 import org.hibernate.annotations.GenericGenerator;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.NamedQueries;
-import javax.persistence.NamedQuery;
-import javax.persistence.Table;
-import java.math.BigDecimal;
-
-/**
- * Hibernate entity for the persistence of HandicapGroups.
- */
 @Entity
 @Table(name = "handicap_groups")
 @NamedQueries({

--- a/dropwizard-app/src/main/java/org/coner/hibernate/entity/Registration.java
+++ b/dropwizard-app/src/main/java/org/coner/hibernate/entity/Registration.java
@@ -1,20 +1,8 @@
 package org.coner.hibernate.entity;
 
+import javax.persistence.*;
 import org.hibernate.annotations.GenericGenerator;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.ManyToOne;
-import javax.persistence.NamedQueries;
-import javax.persistence.NamedQuery;
-import javax.persistence.Table;
-
-
-/**
- * Hibernate entity for the persistence of Registrations.
- */
 @Entity
 @Table(name = "registrations")
 @NamedQueries({

--- a/dropwizard-app/src/main/java/org/coner/resource/CompetitionGroupResource.java
+++ b/dropwizard-app/src/main/java/org/coner/resource/CompetitionGroupResource.java
@@ -1,29 +1,16 @@
 package org.coner.resource;
 
-import com.wordnik.swagger.annotations.Api;
-import com.wordnik.swagger.annotations.ApiOperation;
-import com.wordnik.swagger.annotations.ApiParam;
-import com.wordnik.swagger.annotations.ApiResponse;
-import com.wordnik.swagger.annotations.ApiResponses;
-import io.dropwizard.hibernate.UnitOfWork;
 import org.coner.api.entity.CompetitionGroup;
 import org.coner.api.response.ErrorsResponse;
 import org.coner.boundary.CompetitionGroupBoundary;
 import org.coner.core.ConerCoreService;
+
+import com.wordnik.swagger.annotations.*;
+import io.dropwizard.hibernate.UnitOfWork;
+import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
 import org.eclipse.jetty.http.HttpStatus;
 
-import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
-import javax.ws.rs.NotFoundException;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-
-/**
- * The CompetitionGroupResource exposes getting, updating, and deleting a
- * CompetitionGroup via the REST API.
- */
 @Path("/competitionGroups/{competitionGroupId}")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
@@ -33,13 +20,6 @@ public class CompetitionGroupResource {
     private final CompetitionGroupBoundary competitionGroupBoundary;
     private final ConerCoreService conerCoreService;
 
-    /**
-     * Constructor for the CompetitionGroupResource
-     *
-     * @param competitionGroupBoundary the CompetitionGroupBoundary to use for converting API and Domain
-     *                                 CompetitionGroup entities
-     * @param conerCoreService         the ConerCoreService
-     */
     public CompetitionGroupResource(
             CompetitionGroupBoundary competitionGroupBoundary,
             ConerCoreService conerCoreService
@@ -48,13 +28,6 @@ public class CompetitionGroupResource {
         this.conerCoreService = conerCoreService;
     }
 
-    /**
-     * Get a CompetitionGroup by its id.
-     *
-     * @param id the id of the CompetitionGroup to get
-     * @return the CompetitionGroup with the id
-     * @throws javax.ws.rs.NotFoundException if no CompetitionGroup is found having the id
-     */
     @GET
     @UnitOfWork
     @ApiOperation(value = "Get a Competition Group", response = CompetitionGroup.class)

--- a/dropwizard-app/src/main/java/org/coner/resource/CompetitionGroupSetResource.java
+++ b/dropwizard-app/src/main/java/org/coner/resource/CompetitionGroupSetResource.java
@@ -1,14 +1,8 @@
 package org.coner.resource;
 
-import javax.ws.rs.Consumes;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
+import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 
-/**
- * The CompetitionGroupSetResource exposes getting, updating, and deleting a
- * CompetitionGroupSet via the REST API.
- */
 @Path("/competitionGroups/sets/{competitionGroupSetId}")
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)

--- a/dropwizard-app/src/main/java/org/coner/resource/CompetitionGroupSetsResource.java
+++ b/dropwizard-app/src/main/java/org/coner/resource/CompetitionGroupSetsResource.java
@@ -1,35 +1,19 @@
 package org.coner.resource;
 
-import com.wordnik.swagger.annotations.Api;
-import com.wordnik.swagger.annotations.ApiOperation;
-import com.wordnik.swagger.annotations.ApiParam;
-import com.wordnik.swagger.annotations.ApiResponse;
-import com.wordnik.swagger.annotations.ApiResponses;
-import com.wordnik.swagger.annotations.ResponseHeader;
-import io.dropwizard.hibernate.UnitOfWork;
 import org.coner.api.request.AddCompetitionGroupSetRequest;
 import org.coner.api.response.ErrorsResponse;
 import org.coner.boundary.CompetitionGroupSetBoundary;
 import org.coner.core.ConerCoreService;
 import org.coner.core.domain.CompetitionGroup;
+
+import com.wordnik.swagger.annotations.*;
+import io.dropwizard.hibernate.UnitOfWork;
+import java.util.*;
+import javax.validation.Valid;
+import javax.ws.rs.*;
+import javax.ws.rs.core.*;
 import org.eclipse.jetty.http.HttpStatus;
 
-import javax.validation.Valid;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.NotFoundException;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriBuilder;
-import java.util.HashSet;
-import java.util.Set;
-
-/**
- * The CompetitionGroupSetsResource exposes getting and adding CompetitionGroup Sets
- * via the REST API.
- */
 @Path("/competitionGroups/sets")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
@@ -39,13 +23,6 @@ public class CompetitionGroupSetsResource {
     private final CompetitionGroupSetBoundary competitionGroupSetBoundary;
     private final ConerCoreService conerCoreService;
 
-    /**
-     * Constructor for the CompetitionGroupsSetsResource.
-     *
-     * @param competitionGroupSetBoundary the CompetitionGroupSetBoundary to use for converting API and Domain
-     *                                    Competition Group Set entities
-     * @param conerCoreService            the ConerCoreService
-     */
     public CompetitionGroupSetsResource(
             CompetitionGroupSetBoundary competitionGroupSetBoundary,
             ConerCoreService conerCoreService
@@ -54,12 +31,6 @@ public class CompetitionGroupSetsResource {
         this.conerCoreService = conerCoreService;
     }
 
-    /**
-     * Add a competition group set.
-     *
-     * @param request the CompetitionGroupSet to add
-     * @return the response
-     */
     @POST
     @UnitOfWork
     @ApiOperation(

--- a/dropwizard-app/src/main/java/org/coner/resource/CompetitionGroupsResource.java
+++ b/dropwizard-app/src/main/java/org/coner/resource/CompetitionGroupsResource.java
@@ -1,33 +1,18 @@
 package org.coner.resource;
 
-import com.wordnik.swagger.annotations.Api;
-import com.wordnik.swagger.annotations.ApiOperation;
-import com.wordnik.swagger.annotations.ApiParam;
-import com.wordnik.swagger.annotations.ApiResponse;
-import com.wordnik.swagger.annotations.ApiResponses;
-import io.dropwizard.hibernate.UnitOfWork;
 import org.coner.api.entity.CompetitionGroup;
-import org.coner.api.response.ErrorsResponse;
-import org.coner.api.response.GetCompetitionGroupsResponse;
+import org.coner.api.response.*;
 import org.coner.boundary.CompetitionGroupBoundary;
 import org.coner.core.ConerCoreService;
+
+import com.wordnik.swagger.annotations.*;
+import io.dropwizard.hibernate.UnitOfWork;
+import java.util.List;
+import javax.validation.Valid;
+import javax.ws.rs.*;
+import javax.ws.rs.core.*;
 import org.eclipse.jetty.http.HttpStatus;
 
-import javax.validation.Valid;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriBuilder;
-import java.util.List;
-
-/**
- * The CompetitionGroupsResource exposes getting and adding CompetitionGroups
- * via the REST API.
- */
 @Path("/competitionGroups")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
@@ -37,13 +22,6 @@ public class CompetitionGroupsResource {
     private final CompetitionGroupBoundary competitionGroupBoundary;
     private final ConerCoreService conerCoreService;
 
-    /**
-     * Constructor for the CompetitionGroupsResource.
-     *
-     * @param competitionGroupBoundary the HandicapGroupBoundary to use for converting API and Domain Handicap Group
-     *                                 entities
-     * @param conerCoreService         the ConerCoreService
-     */
     public CompetitionGroupsResource(
             CompetitionGroupBoundary competitionGroupBoundary,
             ConerCoreService conerCoreService
@@ -52,12 +30,6 @@ public class CompetitionGroupsResource {
         this.conerCoreService = conerCoreService;
     }
 
-    /**
-     * Add a competition group.
-     *
-     * @param competitionGroup the competitionGroup to add
-     * @return a response containing the added Event
-     */
     @POST
     @UnitOfWork
     @ApiOperation(value = "Add a new Competition Group")
@@ -84,11 +56,6 @@ public class CompetitionGroupsResource {
                 .build();
     }
 
-    /**
-     * Get all competition groups.
-     *
-     * @return a list of all competition groups
-     */
     @GET
     @UnitOfWork
     @ApiOperation(value = "Get all Competition Groups", response = GetCompetitionGroupsResponse.class)

--- a/dropwizard-app/src/main/java/org/coner/resource/EventRegistrationResource.java
+++ b/dropwizard-app/src/main/java/org/coner/resource/EventRegistrationResource.java
@@ -1,33 +1,18 @@
 package org.coner.resource;
 
-import com.wordnik.swagger.annotations.Api;
-import com.wordnik.swagger.annotations.ApiOperation;
-import com.wordnik.swagger.annotations.ApiParam;
-import com.wordnik.swagger.annotations.ApiResponse;
-import com.wordnik.swagger.annotations.ApiResponses;
-import io.dropwizard.hibernate.UnitOfWork;
 import org.coner.api.entity.Registration;
 import org.coner.api.response.ErrorsResponse;
-import org.coner.boundary.EventBoundary;
-import org.coner.boundary.RegistrationBoundary;
+import org.coner.boundary.*;
 import org.coner.core.ConerCoreService;
 import org.coner.core.exception.EventRegistrationMismatchException;
+
+import com.wordnik.swagger.annotations.*;
+import io.dropwizard.hibernate.UnitOfWork;
+import java.util.Arrays;
+import javax.ws.rs.*;
+import javax.ws.rs.core.*;
 import org.eclipse.jetty.http.HttpStatus;
 
-import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
-import javax.ws.rs.NotFoundException;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import java.util.Arrays;
-
-/**
- * The EventRegistrationResource exposes getting, updating, or deleting a
- * Registration for an Event via the REST API.
- */
 @Path("/events/{eventId}/registrations/{registrationId}")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
@@ -38,13 +23,6 @@ public class EventRegistrationResource {
     private final RegistrationBoundary registrationBoundary;
     private final ConerCoreService conerCoreService;
 
-    /**
-     * Constructor for the EventRegistrationResource.
-     *
-     * @param eventBoundary        the EventBoundary to use for converting API and Domain Event entities
-     * @param registrationBoundary the RegistrationBoundary to use for converting API and Domain Registration entities
-     * @param conerCoreService     the conerCoreService
-     */
     public EventRegistrationResource(
             EventBoundary eventBoundary,
             RegistrationBoundary registrationBoundary,
@@ -54,15 +32,6 @@ public class EventRegistrationResource {
         this.conerCoreService = conerCoreService;
     }
 
-    /**
-     * Get a Registration.
-     *
-     * @param eventId        the id of the Event to get
-     * @param registrationId the id of the Registration
-     * @return the Event with the id
-     * @throws javax.ws.rs.NotFoundException if no Event is found having eventId, or if no Registration is found having
-     *                                       registrationId
-     */
     @GET
     @UnitOfWork
     @ApiOperation(value = "Get a specific registration")

--- a/dropwizard-app/src/main/java/org/coner/resource/EventRegistrationsResource.java
+++ b/dropwizard-app/src/main/java/org/coner/resource/EventRegistrationsResource.java
@@ -1,36 +1,18 @@
 package org.coner.resource;
 
-import com.wordnik.swagger.annotations.Api;
-import com.wordnik.swagger.annotations.ApiOperation;
-import com.wordnik.swagger.annotations.ApiParam;
-import com.wordnik.swagger.annotations.ApiResponse;
-import com.wordnik.swagger.annotations.ApiResponses;
-import io.dropwizard.hibernate.UnitOfWork;
 import org.coner.api.entity.Registration;
-import org.coner.api.response.ErrorsResponse;
-import org.coner.api.response.GetEventRegistrationsResponse;
-import org.coner.boundary.EventBoundary;
-import org.coner.boundary.RegistrationBoundary;
+import org.coner.api.response.*;
+import org.coner.boundary.*;
 import org.coner.core.ConerCoreService;
+
+import com.wordnik.swagger.annotations.*;
+import io.dropwizard.hibernate.UnitOfWork;
+import java.util.List;
+import javax.validation.Valid;
+import javax.ws.rs.*;
+import javax.ws.rs.core.*;
 import org.eclipse.jetty.http.HttpStatus;
 
-import javax.validation.Valid;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
-import javax.ws.rs.NotFoundException;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriBuilder;
-import java.util.List;
-
-/**
- * The EventRegistrationsResource exposes getting Registrations for an Event
- * or adding a Registration for an Event via the REST API.
- */
 @Path("/events/{eventId}/registrations")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
@@ -41,13 +23,6 @@ public class EventRegistrationsResource {
     private final RegistrationBoundary registrationBoundary;
     private final ConerCoreService conerCoreService;
 
-    /**
-     * Constructor for the EventRegistrationResource.
-     *
-     * @param eventBoundary        the EventBoundary to use for converting API and Domain Event entities
-     * @param registrationBoundary the RegistrationBoundary to use for converting API and Domain Registration entities
-     * @param conerCoreService     the conerCoreService
-     */
     public EventRegistrationsResource(
             EventBoundary eventBoundary,
             RegistrationBoundary registrationBoundary,
@@ -57,13 +32,6 @@ public class EventRegistrationsResource {
         this.conerCoreService = conerCoreService;
     }
 
-    /**
-     * Get all Registrations for an Event.
-     *
-     * @param eventId the id of the Event to get Registrations
-     * @return a response containing a list of all Registrations
-     * @throws javax.ws.rs.NotFoundException if no Event is found having the id
-     */
     @GET
     @UnitOfWork
     @ApiOperation(
@@ -97,14 +65,6 @@ public class EventRegistrationsResource {
         return response;
     }
 
-    /**
-     * Add a new Registration for an Event.
-     *
-     * @param eventId      the id of the Event to get Registrations
-     * @param registration the Registration to add
-     * @return a response containing response code and url of the added registration
-     * @throws javax.ws.rs.NotFoundException if no Event is found having the id
-     */
     @POST
     @UnitOfWork
     @ApiOperation(value = "Add a new registration")

--- a/dropwizard-app/src/main/java/org/coner/resource/EventResource.java
+++ b/dropwizard-app/src/main/java/org/coner/resource/EventResource.java
@@ -1,28 +1,16 @@
 package org.coner.resource;
 
-import com.wordnik.swagger.annotations.Api;
-import com.wordnik.swagger.annotations.ApiOperation;
-import com.wordnik.swagger.annotations.ApiParam;
-import com.wordnik.swagger.annotations.ApiResponse;
-import com.wordnik.swagger.annotations.ApiResponses;
-import io.dropwizard.hibernate.UnitOfWork;
 import org.coner.api.entity.Event;
 import org.coner.api.response.ErrorsResponse;
 import org.coner.boundary.EventBoundary;
 import org.coner.core.ConerCoreService;
+
+import com.wordnik.swagger.annotations.*;
+import io.dropwizard.hibernate.UnitOfWork;
+import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
 import org.eclipse.jetty.http.HttpStatus;
 
-import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
-import javax.ws.rs.NotFoundException;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-
-/**
- * The EventResource exposes getting, updating, and deleting an Event via the REST API.
- */
 @Path("/events/{eventId}")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
@@ -32,24 +20,11 @@ public class EventResource {
     private final EventBoundary eventBoundary;
     private final ConerCoreService conerCoreService;
 
-    /**
-     * Constructor for the EventResource.
-     *
-     * @param eventBoundary    the EventBoundary to use for converting API and Domain Event entities
-     * @param conerCoreService the ConerCoreService
-     */
     public EventResource(EventBoundary eventBoundary, ConerCoreService conerCoreService) {
         this.eventBoundary = eventBoundary;
         this.conerCoreService = conerCoreService;
     }
 
-    /**
-     * Get an Event.
-     *
-     * @param id the id of the Event to get
-     * @return the Event with the id
-     * @throws javax.ws.rs.NotFoundException if no Event is found having the id
-     */
     @GET
     @UnitOfWork
     @ApiOperation(value = "Get an Event")

--- a/dropwizard-app/src/main/java/org/coner/resource/EventsResource.java
+++ b/dropwizard-app/src/main/java/org/coner/resource/EventsResource.java
@@ -1,32 +1,18 @@
 package org.coner.resource;
 
-import com.wordnik.swagger.annotations.Api;
-import com.wordnik.swagger.annotations.ApiOperation;
-import com.wordnik.swagger.annotations.ApiParam;
-import com.wordnik.swagger.annotations.ApiResponse;
-import com.wordnik.swagger.annotations.ApiResponses;
-import io.dropwizard.hibernate.UnitOfWork;
 import org.coner.api.entity.Event;
-import org.coner.api.response.ErrorsResponse;
-import org.coner.api.response.GetEventsResponse;
+import org.coner.api.response.*;
 import org.coner.boundary.EventBoundary;
 import org.coner.core.ConerCoreService;
+
+import com.wordnik.swagger.annotations.*;
+import io.dropwizard.hibernate.UnitOfWork;
+import java.util.List;
+import javax.validation.Valid;
+import javax.ws.rs.*;
+import javax.ws.rs.core.*;
 import org.eclipse.jetty.http.HttpStatus;
 
-import javax.validation.Valid;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriBuilder;
-import java.util.List;
-
-/**
- * The EventsResource exposes getting and adding Events via the REST API.
- */
 @Path("/events")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
@@ -36,22 +22,11 @@ public class EventsResource {
     private final EventBoundary eventBoundary;
     private final ConerCoreService conerCoreService;
 
-    /**
-     * Constructor for the EventsResource.
-     *
-     * @param eventBoundary    the EventBoundary to use for converting API and Domain Event entities
-     * @param conerCoreService the ConerCoreService
-     */
     public EventsResource(EventBoundary eventBoundary, ConerCoreService conerCoreService) {
         this.eventBoundary = eventBoundary;
         this.conerCoreService = conerCoreService;
     }
 
-    /**
-     * Get all events.
-     *
-     * @return a list of all events
-     */
     @GET
     @UnitOfWork
     @ApiOperation(value = "Get a list of all events", response = GetEventsResponse.class)
@@ -62,12 +37,6 @@ public class EventsResource {
         return response;
     }
 
-    /**
-     * Add an event.
-     *
-     * @param event the Event to add
-     * @return a response containing the response code and url of the added event
-     */
     @POST
     @UnitOfWork
     @ApiOperation(value = "Add an Event", response = Response.class)

--- a/dropwizard-app/src/main/java/org/coner/resource/HandicapGroupResource.java
+++ b/dropwizard-app/src/main/java/org/coner/resource/HandicapGroupResource.java
@@ -1,29 +1,16 @@
 package org.coner.resource;
 
-import com.wordnik.swagger.annotations.Api;
-import com.wordnik.swagger.annotations.ApiOperation;
-import com.wordnik.swagger.annotations.ApiParam;
-import com.wordnik.swagger.annotations.ApiResponse;
-import com.wordnik.swagger.annotations.ApiResponses;
-import io.dropwizard.hibernate.UnitOfWork;
 import org.coner.api.entity.HandicapGroup;
 import org.coner.api.response.ErrorsResponse;
 import org.coner.boundary.HandicapGroupBoundary;
 import org.coner.core.ConerCoreService;
+
+import com.wordnik.swagger.annotations.*;
+import io.dropwizard.hibernate.UnitOfWork;
+import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
 import org.eclipse.jetty.http.HttpStatus;
 
-import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
-import javax.ws.rs.NotFoundException;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-
-/**
- * The HandicapGroupResource exposes getting, updating, and deleting a
- * HandicapGroup via the REST API.
- */
 @Path("/handicapGroups/{handicapGroupId}")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
@@ -33,25 +20,11 @@ public class HandicapGroupResource {
     private final HandicapGroupBoundary handicapGroupBoundary;
     private final ConerCoreService conerCoreService;
 
-    /**
-     * Constructor for the HandicapGroupResource
-     *
-     * @param handicapGroupBoundary the HandicapGroupBoundary to use for converting API and Domain HandicapGroup
-     *                              entities
-     * @param conerCoreService      the ConerCoreService
-     */
     public HandicapGroupResource(HandicapGroupBoundary handicapGroupBoundary, ConerCoreService conerCoreService) {
         this.handicapGroupBoundary = handicapGroupBoundary;
         this.conerCoreService = conerCoreService;
     }
 
-    /**
-     * Get a HandicapGroup by its id.
-     *
-     * @param id the id of the HandicapGroup to get
-     * @return the HandicapGroup with the id
-     * @throws javax.ws.rs.NotFoundException if no HandicapGroup is found having the id
-     */
     @GET
     @UnitOfWork
     @ApiOperation(value = "Get a Handicap Group", response = HandicapGroup.class)

--- a/dropwizard-app/src/main/java/org/coner/resource/HandicapGroupSetResource.java
+++ b/dropwizard-app/src/main/java/org/coner/resource/HandicapGroupSetResource.java
@@ -1,8 +1,4 @@
 package org.coner.resource;
 
-/**
- * The HandicapGroupSetResource exposes getting, updating, and deleting a
- * HandicapGroupSet via the REST API.
- */
 public class HandicapGroupSetResource {
 }

--- a/dropwizard-app/src/main/java/org/coner/resource/HandicapGroupSetsResource.java
+++ b/dropwizard-app/src/main/java/org/coner/resource/HandicapGroupSetsResource.java
@@ -1,7 +1,4 @@
 package org.coner.resource;
 
-/**
- * The HandicapGroupSetsResource exposes getting and adding HandicapGroupSets via the REST API.
- */
 public class HandicapGroupSetsResource {
 }

--- a/dropwizard-app/src/main/java/org/coner/resource/HandicapGroupsResource.java
+++ b/dropwizard-app/src/main/java/org/coner/resource/HandicapGroupsResource.java
@@ -1,32 +1,18 @@
 package org.coner.resource;
 
-import com.wordnik.swagger.annotations.Api;
-import com.wordnik.swagger.annotations.ApiOperation;
-import com.wordnik.swagger.annotations.ApiParam;
-import com.wordnik.swagger.annotations.ApiResponse;
-import com.wordnik.swagger.annotations.ApiResponses;
-import io.dropwizard.hibernate.UnitOfWork;
 import org.coner.api.entity.HandicapGroup;
-import org.coner.api.response.ErrorsResponse;
-import org.coner.api.response.GetHandicapGroupsResponse;
+import org.coner.api.response.*;
 import org.coner.boundary.HandicapGroupBoundary;
 import org.coner.core.ConerCoreService;
+
+import com.wordnik.swagger.annotations.*;
+import io.dropwizard.hibernate.UnitOfWork;
+import java.util.List;
+import javax.validation.Valid;
+import javax.ws.rs.*;
+import javax.ws.rs.core.*;
 import org.eclipse.jetty.http.HttpStatus;
 
-import javax.validation.Valid;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriBuilder;
-import java.util.List;
-
-/**
- * The HandicapGroupsResource exposes getting and adding Handicap Groups via the REST API.
- */
 @Path("/handicapGroups")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
@@ -36,24 +22,11 @@ public class HandicapGroupsResource {
     private final HandicapGroupBoundary handicapGroupBoundary;
     private final ConerCoreService conerCoreService;
 
-    /**
-     * Constructor for the HandicapGroupsResource.
-     *
-     * @param handicapGroupBoundary the HandicapGroupBoundary to use for converting API and
-     *                              Domain Handicap Group entities
-     * @param conerCoreService      the ConerCoreService
-     */
     public HandicapGroupsResource(HandicapGroupBoundary handicapGroupBoundary, ConerCoreService conerCoreService) {
         this.handicapGroupBoundary = handicapGroupBoundary;
         this.conerCoreService = conerCoreService;
     }
 
-    /**
-     * Add a HandicapGroup.
-     *
-     * @param handicapGroup the handicap group to add
-     * @return a response containing response code and url of the added handicap group
-     */
     @POST
     @UnitOfWork
     @ApiOperation(value = "Add a Handicap Group")
@@ -78,11 +51,6 @@ public class HandicapGroupsResource {
                 .build();
     }
 
-    /**
-     * Get all handicap groups.
-     *
-     * @return a list of all handicap groups
-     */
     @GET
     @UnitOfWork
     @ApiOperation(value = "Get all Handicap Groups", response = GetHandicapGroupsResponse.class)

--- a/dropwizard-app/src/test/java/org/coner/ConerDropwizardApplicationTest.java
+++ b/dropwizard-app/src/test/java/org/coner/ConerDropwizardApplicationTest.java
@@ -1,45 +1,23 @@
 package org.coner;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
+import org.coner.boundary.*;
+import org.coner.core.ConerCoreService;
+import org.coner.core.gateway.*;
+import org.coner.exception.WebApplicationExceptionMapper;
+import org.coner.hibernate.dao.*;
+import org.coner.resource.*;
+
+import com.fasterxml.jackson.databind.*;
 import io.dropwizard.db.DataSourceFactory;
 import io.dropwizard.hibernate.HibernateBundle;
 import io.dropwizard.jersey.setup.JerseyEnvironment;
-import io.dropwizard.setup.Bootstrap;
-import io.dropwizard.setup.Environment;
-import org.coner.boundary.CompetitionGroupBoundary;
-import org.coner.boundary.EventBoundary;
-import org.coner.boundary.HandicapGroupBoundary;
-import org.coner.boundary.RegistrationBoundary;
-import org.coner.core.ConerCoreService;
-import org.coner.core.gateway.CompetitionGroupGateway;
-import org.coner.core.gateway.EventGateway;
-import org.coner.core.gateway.HandicapGroupGateway;
-import org.coner.core.gateway.RegistrationGateway;
-import org.coner.exception.WebApplicationExceptionMapper;
-import org.coner.hibernate.dao.CompetitionGroupDao;
-import org.coner.hibernate.dao.EventDao;
-import org.coner.hibernate.dao.HandicapGroupDao;
-import org.coner.hibernate.dao.RegistrationDao;
-import org.coner.resource.CompetitionGroupResource;
-import org.coner.resource.CompetitionGroupSetsResource;
-import org.coner.resource.CompetitionGroupsResource;
-import org.coner.resource.EventRegistrationResource;
-import org.coner.resource.EventRegistrationsResource;
-import org.coner.resource.EventResource;
-import org.coner.resource.EventsResource;
-import org.coner.resource.HandicapGroupResource;
-import org.coner.resource.HandicapGroupsResource;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
-
-import java.util.ArrayList;
-import java.util.List;
+import io.dropwizard.setup.*;
+import java.util.*;
 import java.util.stream.Collectors;
+import org.junit.*;
+import org.junit.runner.RunWith;
+import org.mockito.*;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -47,9 +25,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-/**
- *
- */
 @RunWith(MockitoJUnitRunner.class)
 public class ConerDropwizardApplicationTest {
 
@@ -59,7 +34,7 @@ public class ConerDropwizardApplicationTest {
     // application dependencies
     private final HibernateBundle<ConerDropwizardConfiguration> hibernate = mock(HibernateBundle.class);
     private final ConerCoreService conerCoreService = mock(ConerCoreService.class);
-
+    private final ConerDropwizardApplication application = new ConerDropwizardApplication();
     // Event
     @Mock
     private EventBoundary eventBoundary;
@@ -67,7 +42,6 @@ public class ConerDropwizardApplicationTest {
     private EventDao eventDao;
     @Mock
     private EventGateway eventGateway;
-
     // Registration
     @Mock
     private RegistrationBoundary registrationBoundary;
@@ -75,7 +49,6 @@ public class ConerDropwizardApplicationTest {
     private RegistrationDao registrationDao;
     @Mock
     private RegistrationGateway registrationGateway;
-
     // HandicapGroup
     @Mock
     private HandicapGroupBoundary handicapGroupBoundary;
@@ -83,7 +56,6 @@ public class ConerDropwizardApplicationTest {
     private HandicapGroupDao handicapGroupDao;
     @Mock
     private HandicapGroupGateway handicapGroupGateway;
-
     // Competition Group
     @Mock
     private CompetitionGroupBoundary competitionGroupBoundary;
@@ -91,14 +63,11 @@ public class ConerDropwizardApplicationTest {
     private CompetitionGroupDao competitionGroupDao;
     @Mock
     private CompetitionGroupGateway competitionGroupGateway;
-
-
     // initialize method parameters
     @Mock
     private Bootstrap<ConerDropwizardConfiguration> bootstrap;
     @Mock
     private ObjectMapper objectMapper;
-
     // run method parameters
     @Mock
     private ConerDropwizardConfiguration config;
@@ -108,8 +77,6 @@ public class ConerDropwizardApplicationTest {
     private Environment environment;
     @Mock
     private JerseyEnvironment jersey;
-
-    private final ConerDropwizardApplication application = new ConerDropwizardApplication();
 
     @Before
     public void setup() {

--- a/dropwizard-app/src/test/java/org/coner/api/entity/CompetitionGroupEntityTest.java
+++ b/dropwizard-app/src/test/java/org/coner/api/entity/CompetitionGroupEntityTest.java
@@ -1,18 +1,14 @@
 package org.coner.api.entity;
 
+import org.coner.util.*;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.jackson.Jackson;
 import io.dropwizard.testing.FixtureHelpers;
 import org.assertj.core.api.Assertions;
-import org.coner.util.ApiEntityTestUtils;
-import org.coner.util.JacksonUtil;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
 import org.skyscreamer.jsonassert.JSONAssert;
 
-/**
- *
- */
 public class CompetitionGroupEntityTest {
     private final String fixturePath = "fixtures/api/entity/competition_group_full.json";
 

--- a/dropwizard-app/src/test/java/org/coner/api/entity/EventEntityTest.java
+++ b/dropwizard-app/src/test/java/org/coner/api/entity/EventEntityTest.java
@@ -1,19 +1,15 @@
 package org.coner.api.entity;
 
+import org.coner.util.*;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.jackson.Jackson;
-import org.coner.util.ApiEntityTestUtils;
-import org.coner.util.JacksonUtil;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
 import org.skyscreamer.jsonassert.JSONAssert;
 
 import static io.dropwizard.testing.FixtureHelpers.fixture;
 import static org.fest.assertions.Assertions.assertThat;
 
-/**
- *
- */
 public class EventEntityTest {
 
     private final String fixturePath = "fixtures/api/entity/event_full.json";

--- a/dropwizard-app/src/test/java/org/coner/api/entity/HandicapGroupEntityTest.java
+++ b/dropwizard-app/src/test/java/org/coner/api/entity/HandicapGroupEntityTest.java
@@ -1,19 +1,15 @@
 package org.coner.api.entity;
 
+import org.coner.util.*;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.jackson.Jackson;
-import org.coner.util.ApiEntityTestUtils;
-import org.coner.util.JacksonUtil;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
 import org.skyscreamer.jsonassert.JSONAssert;
 
 import static io.dropwizard.testing.FixtureHelpers.fixture;
 import static org.fest.assertions.Assertions.assertThat;
 
-/**
- *
- */
 public class HandicapGroupEntityTest {
     private final String fixturePath = "fixtures/api/entity/handicap_group_full.json";
 

--- a/dropwizard-app/src/test/java/org/coner/api/entity/RegistrationEntityTest.java
+++ b/dropwizard-app/src/test/java/org/coner/api/entity/RegistrationEntityTest.java
@@ -1,19 +1,15 @@
 package org.coner.api.entity;
 
+import org.coner.util.*;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.jackson.Jackson;
-import org.coner.util.ApiEntityTestUtils;
-import org.coner.util.JacksonUtil;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
 import org.skyscreamer.jsonassert.JSONAssert;
 
 import static io.dropwizard.testing.FixtureHelpers.fixture;
 import static org.fest.assertions.Assertions.assertThat;
 
-/**
- *
- **/
 public class RegistrationEntityTest {
     private final String fixturePath = "fixtures/api/entity/registration_full.json";
 

--- a/dropwizard-app/src/test/java/org/coner/boundary/AbstractBoundaryTest.java
+++ b/dropwizard-app/src/test/java/org/coner/boundary/AbstractBoundaryTest.java
@@ -3,16 +3,13 @@ package org.coner.boundary;
 import org.coner.api.entity.ApiEntity;
 import org.coner.core.domain.DomainEntity;
 import org.coner.hibernate.entity.HibernateEntity;
-import org.junit.Before;
-import org.junit.Test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.*;
+import org.junit.*;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-
-import java.lang.reflect.InvocationTargetException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Random;
 
 import static org.assertj.core.api.Fail.failBecauseExceptionWasNotThrown;
 import static org.fest.assertions.Assertions.assertThat;
@@ -21,14 +18,14 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-/**
- *
- */
 @RunWith(MockitoJUnitRunner.class)
 public class AbstractBoundaryTest {
 
+    private final Class<TestApiEntity> apiClass = TestApiEntity.class;
+    private final Class<TestDomainEntity> domainClass = TestDomainEntity.class;
+    private final Class<TestHibernateEntity> hibernateClass = TestHibernateEntity.class;
+    private final Random random = new Random();
     private AbstractBoundary<TestApiEntity, TestDomainEntity, TestHibernateEntity> abstractBoundary;
-
     @Mock
     private EntityMerger<TestApiEntity, TestDomainEntity> apiToDomainMerger;
     @Mock
@@ -37,11 +34,6 @@ public class AbstractBoundaryTest {
     private EntityMerger<TestDomainEntity, TestHibernateEntity> domainToHibernateMerger;
     @Mock
     private EntityMerger<TestHibernateEntity, TestDomainEntity> hibernateToDomainMerger;
-
-    private final Class<TestApiEntity> apiClass = TestApiEntity.class;
-    private final Class<TestDomainEntity> domainClass = TestDomainEntity.class;
-    private final Class<TestHibernateEntity> hibernateClass = TestHibernateEntity.class;
-    private final Random random = new Random();
 
     @Before
     public void setup() {
@@ -366,29 +358,6 @@ public class AbstractBoundaryTest {
         }
     }
 
-    private class TestBoundary extends AbstractBoundary<TestApiEntity, TestDomainEntity, TestHibernateEntity> {
-
-        @Override
-        protected EntityMerger<TestApiEntity, TestDomainEntity> buildApiToDomainMerger() {
-            return apiToDomainMerger;
-        }
-
-        @Override
-        protected EntityMerger<TestDomainEntity, TestApiEntity> buildDomainToApiMerger() {
-            return domainToApiMerger;
-        }
-
-        @Override
-        protected EntityMerger<TestDomainEntity, TestHibernateEntity> buildDomainToHibernateMerger() {
-            return domainToHibernateMerger;
-        }
-
-        @Override
-        protected EntityMerger<TestHibernateEntity, TestDomainEntity> buildHibernateToDomainMerger() {
-            return hibernateToDomainMerger;
-        }
-    }
-
     public static class TestApiEntity extends ApiEntity {
     }
 
@@ -410,6 +379,29 @@ public class AbstractBoundaryTest {
     }
 
     public abstract static class AbstractEntity {
+    }
+
+    private class TestBoundary extends AbstractBoundary<TestApiEntity, TestDomainEntity, TestHibernateEntity> {
+
+        @Override
+        protected EntityMerger<TestApiEntity, TestDomainEntity> buildApiToDomainMerger() {
+            return apiToDomainMerger;
+        }
+
+        @Override
+        protected EntityMerger<TestDomainEntity, TestApiEntity> buildDomainToApiMerger() {
+            return domainToApiMerger;
+        }
+
+        @Override
+        protected EntityMerger<TestDomainEntity, TestHibernateEntity> buildDomainToHibernateMerger() {
+            return domainToHibernateMerger;
+        }
+
+        @Override
+        protected EntityMerger<TestHibernateEntity, TestDomainEntity> buildHibernateToDomainMerger() {
+            return hibernateToDomainMerger;
+        }
     }
 
 }

--- a/dropwizard-app/src/test/java/org/coner/boundary/EventBoundaryTest.java
+++ b/dropwizard-app/src/test/java/org/coner/boundary/EventBoundaryTest.java
@@ -1,28 +1,20 @@
 package org.coner.boundary;
 
-import org.assertj.core.api.Assertions;
 import org.coner.core.domain.Event;
-import org.coner.util.ApiEntityTestUtils;
-import org.coner.util.DomainEntityTestUtils;
-import org.coner.util.HibernateEntityUtils;
-import org.coner.util.TestConstants;
-import org.junit.Before;
-import org.junit.Test;
+import org.coner.util.*;
 
 import java.util.Date;
+import org.assertj.core.api.Assertions;
+import org.junit.*;
 
 import static org.fest.assertions.Assertions.assertThat;
 
-/**
- *
- */
 public class EventBoundaryTest {
-
-    private EventBoundary eventBoundary;
 
     private final String id = TestConstants.EVENT_ID;
     private final String name = TestConstants.EVENT_NAME;
     private final Date date = TestConstants.EVENT_DATE;
+    private EventBoundary eventBoundary;
 
     @Before
     public void setup() {

--- a/dropwizard-app/src/test/java/org/coner/boundary/ReflectionEntityMergerTest.java
+++ b/dropwizard-app/src/test/java/org/coner/boundary/ReflectionEntityMergerTest.java
@@ -1,15 +1,11 @@
 package org.coner.boundary;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-/**
- *
- */
 public class ReflectionEntityMergerTest {
 
     private static final String VALUE_PROPERTY_COMMON = "property-common";
@@ -25,7 +21,6 @@ public class ReflectionEntityMergerTest {
     private static final String VALUE_PROPERTY_STRING_WITH_DESTINATION_ENUM = "EAST";
     private static final TestSourceEntity.Status VALUE_PROPERTY_ENUM_WITH_STRING_DESTINATION =
             TestSourceEntity.Status.PLAYING;
-
 
     private TestSourceEntity testSourceEntity;
     private TestDestinationEntity testDestinationEntity;
@@ -135,7 +130,8 @@ public class ReflectionEntityMergerTest {
                 String propertyWithNonStandardGetterSetterMethodName,
                 String propertyWithGetterWithParameter,
                 String propertyWithSetterWithMoreThanOneParameter,
-                String propertyStringWithDestinationEnum, Status propertyEnumWithStringDestination) {
+                String propertyStringWithDestinationEnum,
+                Status propertyEnumWithStringDestination) {
             this.propertyCommon = propertyCommon;
             this.propertyBoolean = propertyBoolean;
             this.propertyWithDifferentType = propertyWithDifferentType;
@@ -246,24 +242,12 @@ public class ReflectionEntityMergerTest {
         private Direction propertyStringWithDestinationEnum;
         private String propertyEnumWithStringDestination;
 
-        public void setPropertyCommon(String propertyCommon) {
-            this.propertyCommon = propertyCommon;
-        }
-
         public boolean isPropertyBoolean() {
             return propertyBoolean;
         }
 
         public void setPropertyBoolean(boolean propertyBoolean) {
             this.propertyBoolean = propertyBoolean;
-        }
-
-        public void setPropertyWithDifferentType(int propertyWithDifferentType) {
-            this.propertyWithDifferentType = propertyWithDifferentType;
-        }
-
-        public void setPropertyWithSetterOfDifferentName(String propertyWithSetterOfDifferentName) {
-            this.propertyWithSetterOfDifferentName = propertyWithSetterOfDifferentName;
         }
 
         public void putPropertyWithNonStandardGetterSetterMethodName(String stuff) {
@@ -274,12 +258,24 @@ public class ReflectionEntityMergerTest {
             return propertyCommon;
         }
 
+        public void setPropertyCommon(String propertyCommon) {
+            this.propertyCommon = propertyCommon;
+        }
+
         public int getPropertyWithDifferentType() {
             return propertyWithDifferentType;
         }
 
+        public void setPropertyWithDifferentType(int propertyWithDifferentType) {
+            this.propertyWithDifferentType = propertyWithDifferentType;
+        }
+
         public String getPropertyWithSetterOfDifferentName() {
             return propertyWithSetterOfDifferentName;
+        }
+
+        public void setPropertyWithSetterOfDifferentName(String propertyWithSetterOfDifferentName) {
+            this.propertyWithSetterOfDifferentName = propertyWithSetterOfDifferentName;
         }
 
         public String getPropertyWithNonStandardGetterSetterMethodName() {

--- a/dropwizard-app/src/test/java/org/coner/boundary/RegistrationBoundaryTest.java
+++ b/dropwizard-app/src/test/java/org/coner/boundary/RegistrationBoundaryTest.java
@@ -1,18 +1,13 @@
 package org.coner.boundary;
 
 import org.coner.core.domain.Registration;
-import org.coner.util.ApiEntityTestUtils;
-import org.coner.util.DomainEntityTestUtils;
-import org.coner.util.TestConstants;
-import org.junit.Before;
-import org.junit.Test;
+import org.coner.util.*;
+
+import org.junit.*;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-/**
- *
- */
 public class RegistrationBoundaryTest {
 
     private final EventBoundary eventBoundary = mock(EventBoundary.class);

--- a/dropwizard-app/src/test/java/org/coner/core/ConerCoreServiceTest.java
+++ b/dropwizard-app/src/test/java/org/coner/core/ConerCoreServiceTest.java
@@ -1,22 +1,13 @@
 package org.coner.core;
 
-import org.coner.core.domain.CompetitionGroup;
-import org.coner.core.domain.Event;
-import org.coner.core.domain.HandicapGroup;
-import org.coner.core.domain.Registration;
-import org.coner.core.gateway.CompetitionGroupGateway;
-import org.coner.core.gateway.CompetitionGroupSetGateway;
-import org.coner.core.gateway.EventGateway;
-import org.coner.core.gateway.HandicapGroupGateway;
-import org.coner.core.gateway.RegistrationGateway;
-import org.junit.Before;
-import org.junit.Test;
+import org.coner.core.domain.*;
+import org.coner.core.gateway.*;
+
+import java.util.*;
+import org.junit.*;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Fail.failBecauseExceptionWasNotThrown;
@@ -26,9 +17,6 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
-/**
- *
- */
 @RunWith(MockitoJUnitRunner.class)
 public class ConerCoreServiceTest {
 

--- a/dropwizard-app/src/test/java/org/coner/core/gateway/EventGatewayTest.java
+++ b/dropwizard-app/src/test/java/org/coner/core/gateway/EventGatewayTest.java
@@ -4,14 +4,12 @@ package org.coner.core.gateway;
 import org.coner.boundary.EventBoundary;
 import org.coner.core.domain.Event;
 import org.coner.hibernate.dao.EventDao;
-import org.junit.Before;
-import org.junit.Test;
+
+import java.util.*;
+import org.junit.*;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Fail.failBecauseExceptionWasNotThrown;
@@ -21,9 +19,6 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
-/**
- *
- */
 @RunWith(MockitoJUnitRunner.class)
 public class EventGatewayTest {
 

--- a/dropwizard-app/src/test/java/org/coner/hibernate/dao/AbstractDaoTest.java
+++ b/dropwizard-app/src/test/java/org/coner/hibernate/dao/AbstractDaoTest.java
@@ -1,29 +1,19 @@
 package org.coner.hibernate.dao;
 
+import org.coner.hibernate.entity.*;
+
 import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.db.DataSourceFactory;
+import java.sql.*;
+import java.util.*;
 import org.assertj.core.api.Assertions;
-import org.coner.hibernate.entity.Event;
-import org.coner.hibernate.entity.HibernateEntity;
-import org.coner.hibernate.entity.Registration;
-import org.hibernate.Session;
-import org.hibernate.SessionFactory;
+import org.hibernate.*;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
-import org.hibernate.cfg.AvailableSettings;
-import org.hibernate.cfg.Configuration;
-import org.hibernate.cfg.Environment;
+import org.hibernate.cfg.*;
 import org.hibernate.engine.jdbc.connections.internal.DatasourceConnectionProviderImpl;
 import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
 import org.hibernate.service.ServiceRegistry;
 
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.util.HashMap;
-import java.util.Map;
-
-/**
- *
- */
 public abstract class AbstractDaoTest {
 
     private final Class<? extends HibernateEntity>[] hibernateEntityClasses = new Class[]{

--- a/dropwizard-app/src/test/java/org/coner/hibernate/dao/EventDaoTest.java
+++ b/dropwizard-app/src/test/java/org/coner/hibernate/dao/EventDaoTest.java
@@ -1,26 +1,19 @@
 package org.coner.hibernate.dao;
 
 import org.coner.hibernate.entity.Event;
-import org.hibernate.Query;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
 
 import java.time.ZonedDateTime;
-import java.util.Date;
-import java.util.List;
+import java.util.*;
+import org.hibernate.Query;
+import org.junit.*;
 
 import static org.fest.assertions.Assertions.assertThat;
 
-/**
- *
- */
 public class EventDaoTest extends AbstractDaoTest {
-
-    private EventDao eventDao;
 
     private final String name = "EventDao test event";
     private final Date date = Date.from(ZonedDateTime.parse("2014-12-26T22:12:00-05:00").toInstant());
+    private EventDao eventDao;
 
     @Before
     public void setup() {

--- a/dropwizard-app/src/test/java/org/coner/it/AbstractIntegrationTest.java
+++ b/dropwizard-app/src/test/java/org/coner/it/AbstractIntegrationTest.java
@@ -1,16 +1,11 @@
 package org.coner.it;
 
-import io.dropwizard.testing.junit.DropwizardAppRule;
 import org.coner.ConerDropwizardConfiguration;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
 
+import io.dropwizard.testing.junit.DropwizardAppRule;
 import javax.ws.rs.client.Client;
+import org.junit.*;
 
-/**
- *
- */
 public class AbstractIntegrationTest {
     @ClassRule
     public static final DropwizardAppRule<ConerDropwizardConfiguration> RULE = IntegrationTestUtils.buildAppRule();

--- a/dropwizard-app/src/test/java/org/coner/it/CompetitionGroupIntegrationTest.java
+++ b/dropwizard-app/src/test/java/org/coner/it/CompetitionGroupIntegrationTest.java
@@ -1,24 +1,18 @@
 package org.coner.it;
 
 import org.coner.api.entity.CompetitionGroup;
-import org.coner.api.request.AddCompetitionGroupRequest;
-import org.coner.api.request.AddCompetitionGroupSetRequest;
+import org.coner.api.request.*;
 import org.coner.api.response.ErrorsResponse;
-import org.coner.util.TestConstants;
-import org.coner.util.UnitTestUtils;
+import org.coner.util.*;
+
+import java.net.URI;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.*;
 import org.eclipse.jetty.http.HttpStatus;
 import org.junit.Test;
 
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import java.net.URI;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
-/**
- *
- */
 public class CompetitionGroupIntegrationTest extends AbstractIntegrationTest {
 
     private static final String COMPETITION_GROUPS_PATH = "/competitionGroups";

--- a/dropwizard-app/src/test/java/org/coner/it/EventIntegrationTest.java
+++ b/dropwizard-app/src/test/java/org/coner/it/EventIntegrationTest.java
@@ -2,25 +2,20 @@ package org.coner.it;
 
 import org.coner.api.entity.Event;
 import org.coner.api.request.AddEventRequest;
-import org.coner.api.response.ErrorsResponse;
-import org.coner.api.response.GetEventsResponse;
+import org.coner.api.response.*;
 import org.coner.util.UnitTestUtils;
-import org.eclipse.jetty.http.HttpStatus;
-import org.junit.Test;
 
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 import java.net.URI;
 import java.time.ZonedDateTime;
 import java.util.Date;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.*;
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 
-/**
- *
- */
 public class EventIntegrationTest extends AbstractIntegrationTest {
 
     private final String name = "name";

--- a/dropwizard-app/src/test/java/org/coner/it/HandicapGroupIntegrationTest.java
+++ b/dropwizard-app/src/test/java/org/coner/it/HandicapGroupIntegrationTest.java
@@ -3,21 +3,16 @@ package org.coner.it;
 import org.coner.api.entity.HandicapGroup;
 import org.coner.api.request.AddHandicapGroupRequest;
 import org.coner.api.response.ErrorsResponse;
-import org.coner.util.TestConstants;
-import org.coner.util.UnitTestUtils;
+import org.coner.util.*;
+
+import java.net.URI;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.*;
 import org.eclipse.jetty.http.HttpStatus;
 import org.junit.Test;
 
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import java.net.URI;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
-/**
- *
- */
 public class HandicapGroupIntegrationTest extends AbstractIntegrationTest {
 
     private static final String HANDICAP_GROUPS_PATH = "/handicapGroups";

--- a/dropwizard-app/src/test/java/org/coner/it/IntegrationTestUtils.java
+++ b/dropwizard-app/src/test/java/org/coner/it/IntegrationTestUtils.java
@@ -1,24 +1,19 @@
 package org.coner.it;
 
+import org.coner.*;
+
+import com.google.common.base.Joiner;
 import io.dropwizard.client.JerseyClientBuilder;
 import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit.DropwizardAppRule;
-import com.google.common.base.Joiner;
-import org.coner.ConerDropwizardApplication;
-import org.coner.ConerDropwizardConfiguration;
+import javax.ws.rs.client.Client;
 import org.glassfish.jersey.uri.internal.JerseyUriBuilder;
 
-import javax.ws.rs.client.Client;
-
-/**
- *
- */
 public final class IntegrationTestUtils {
 
     private static final String TEST_CLIENT_NAME = "test-client";
 
     private IntegrationTestUtils() {
-
     }
 
     public static DropwizardAppRule<ConerDropwizardConfiguration> buildAppRule() {

--- a/dropwizard-app/src/test/java/org/coner/it/RegistrationIntegrationTest.java
+++ b/dropwizard-app/src/test/java/org/coner/it/RegistrationIntegrationTest.java
@@ -1,33 +1,24 @@
 package org.coner.it;
 
 import org.coner.api.entity.Registration;
-import org.coner.api.request.AddEventRequest;
-import org.coner.api.request.AddRegistrationRequest;
-import org.coner.api.response.ErrorsResponse;
-import org.coner.api.response.GetEventRegistrationsResponse;
-import org.coner.util.TestConstants;
-import org.coner.util.UnitTestUtils;
-import org.eclipse.jetty.http.HttpStatus;
-import org.junit.Before;
-import org.junit.Test;
+import org.coner.api.request.*;
+import org.coner.api.response.*;
+import org.coner.util.*;
 
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 import java.net.URI;
-import java.util.Date;
-import java.util.List;
+import java.util.*;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.*;
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.*;
 
 import static org.fest.assertions.Assertions.assertThat;
 
-/**
- *
- */
 public class RegistrationIntegrationTest extends AbstractIntegrationTest {
 
-    private String eventId;
     private final String eventName = TestConstants.EVENT_NAME;
     private final Date eventDate = TestConstants.EVENT_DATE;
+    private String eventId;
 
     @Before
     public void setup() {

--- a/dropwizard-app/src/test/java/org/coner/resource/CompetitionGroupResourceTest.java
+++ b/dropwizard-app/src/test/java/org/coner/resource/CompetitionGroupResourceTest.java
@@ -1,20 +1,15 @@
 package org.coner.resource;
 
-import io.dropwizard.jersey.validation.ConstraintViolationExceptionMapper;
-import io.dropwizard.testing.junit.ResourceTestRule;
 import org.coner.api.entity.CompetitionGroup;
 import org.coner.boundary.CompetitionGroupBoundary;
 import org.coner.core.ConerCoreService;
-import org.coner.util.ApiEntityTestUtils;
-import org.coner.util.DomainEntityTestUtils;
-import org.coner.util.TestConstants;
-import org.eclipse.jetty.http.HttpStatus;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.coner.util.*;
 
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import io.dropwizard.jersey.validation.ConstraintViolationExceptionMapper;
+import io.dropwizard.testing.junit.ResourceTestRule;
+import javax.ws.rs.core.*;
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -24,9 +19,6 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
-/**
- *
- */
 public class CompetitionGroupResourceTest {
 
     private final CompetitionGroupBoundary competitionGroupBoundary = mock(CompetitionGroupBoundary.class);

--- a/dropwizard-app/src/test/java/org/coner/resource/CompetitionGroupSetsResourceTest.java
+++ b/dropwizard-app/src/test/java/org/coner/resource/CompetitionGroupSetsResourceTest.java
@@ -1,26 +1,21 @@
 package org.coner.resource;
 
+import org.coner.api.request.AddCompetitionGroupSetRequest;
+import org.coner.boundary.CompetitionGroupSetBoundary;
+import org.coner.core.ConerCoreService;
+import org.coner.core.domain.*;
+import org.coner.util.*;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.jackson.Jackson;
 import io.dropwizard.jersey.validation.ConstraintViolationExceptionMapper;
 import io.dropwizard.testing.FixtureHelpers;
 import io.dropwizard.testing.junit.ResourceTestRule;
-import org.coner.api.request.AddCompetitionGroupSetRequest;
-import org.coner.boundary.CompetitionGroupSetBoundary;
-import org.coner.core.ConerCoreService;
-import org.coner.core.domain.CompetitionGroup;
-import org.coner.core.domain.CompetitionGroupSet;
-import org.coner.util.JacksonUtil;
-import org.coner.util.UnitTestUtils;
-import org.eclipse.jetty.http.HttpStatus;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.mockito.ArgumentCaptor;
-
 import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import javax.ws.rs.core.*;
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.*;
+import org.mockito.ArgumentCaptor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
@@ -30,16 +25,12 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-/**
- *
- */
 public class CompetitionGroupSetsResourceTest {
 
     private CompetitionGroupSetBoundary competitionGroupSetBoundary = mock(CompetitionGroupSetBoundary.class);
     private ConerCoreService conerCoreService = mock(ConerCoreService.class);
-
     private ObjectMapper objectMapper;
-
+    
     @Rule
     public final ResourceTestRule resources = ResourceTestRule.builder()
             .addResource(new CompetitionGroupSetsResource(competitionGroupSetBoundary, conerCoreService))

--- a/dropwizard-app/src/test/java/org/coner/resource/CompetitionGroupsResourceTest.java
+++ b/dropwizard-app/src/test/java/org/coner/resource/CompetitionGroupsResourceTest.java
@@ -1,28 +1,20 @@
 package org.coner.resource;
 
+import org.coner.api.response.*;
+import org.coner.boundary.CompetitionGroupBoundary;
+import org.coner.core.ConerCoreService;
+import org.coner.core.domain.CompetitionGroup;
+import org.coner.util.*;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.jackson.Jackson;
 import io.dropwizard.jersey.validation.ConstraintViolationExceptionMapper;
 import io.dropwizard.testing.junit.ResourceTestRule;
-import org.coner.api.response.ErrorsResponse;
-import org.coner.api.response.GetCompetitionGroupsResponse;
-import org.coner.boundary.CompetitionGroupBoundary;
-import org.coner.core.ConerCoreService;
-import org.coner.core.domain.CompetitionGroup;
-import org.coner.util.ApiEntityTestUtils;
-import org.coner.util.DomainEntityTestUtils;
-import org.coner.util.JacksonUtil;
-import org.coner.util.UnitTestUtils;
-import org.eclipse.jetty.http.HttpStatus;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-
+import java.util.*;
 import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import java.util.ArrayList;
-import java.util.List;
+import javax.ws.rs.core.*;
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.*;
 
 import static io.dropwizard.testing.FixtureHelpers.fixture;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -41,14 +33,12 @@ public class CompetitionGroupsResourceTest {
 
     private CompetitionGroupBoundary competitionGroupBoundary = mock(CompetitionGroupBoundary.class);
     private ConerCoreService conerCoreService = mock(ConerCoreService.class);
-
-    private ObjectMapper objectMapper;
-
     @Rule
     public final ResourceTestRule resources = ResourceTestRule.builder()
             .addResource(new CompetitionGroupsResource(competitionGroupBoundary, conerCoreService))
             .addProvider(new ConstraintViolationExceptionMapper())
             .build();
+    private ObjectMapper objectMapper;
 
     @Before
     public void setup() {

--- a/dropwizard-app/src/test/java/org/coner/resource/EventRegistrationResourceTest.java
+++ b/dropwizard-app/src/test/java/org/coner/resource/EventRegistrationResourceTest.java
@@ -1,22 +1,16 @@
 package org.coner.resource;
 
-import io.dropwizard.jersey.validation.ConstraintViolationExceptionMapper;
-import io.dropwizard.testing.junit.ResourceTestRule;
 import org.coner.api.entity.Registration;
-import org.coner.boundary.EventBoundary;
-import org.coner.boundary.RegistrationBoundary;
+import org.coner.boundary.*;
 import org.coner.core.ConerCoreService;
 import org.coner.core.exception.EventRegistrationMismatchException;
-import org.coner.util.ApiEntityTestUtils;
-import org.coner.util.DomainEntityTestUtils;
-import org.coner.util.TestConstants;
-import org.eclipse.jetty.http.HttpStatus;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.coner.util.*;
 
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import io.dropwizard.jersey.validation.ConstraintViolationExceptionMapper;
+import io.dropwizard.testing.junit.ResourceTestRule;
+import javax.ws.rs.core.*;
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -26,9 +20,6 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
-/**
- *
- */
 public class EventRegistrationResourceTest {
 
     private final EventBoundary eventBoundary = mock(EventBoundary.class);

--- a/dropwizard-app/src/test/java/org/coner/resource/EventRegistrationsResourceTest.java
+++ b/dropwizard-app/src/test/java/org/coner/resource/EventRegistrationsResourceTest.java
@@ -1,28 +1,20 @@
 package org.coner.resource;
 
+import org.coner.api.response.GetEventRegistrationsResponse;
+import org.coner.boundary.*;
+import org.coner.core.ConerCoreService;
+import org.coner.util.*;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.jackson.Jackson;
 import io.dropwizard.jersey.validation.ConstraintViolationExceptionMapper;
 import io.dropwizard.testing.FixtureHelpers;
 import io.dropwizard.testing.junit.ResourceTestRule;
-import org.coner.api.response.GetEventRegistrationsResponse;
-import org.coner.boundary.EventBoundary;
-import org.coner.boundary.RegistrationBoundary;
-import org.coner.core.ConerCoreService;
-import org.coner.util.ApiEntityTestUtils;
-import org.coner.util.DomainEntityTestUtils;
-import org.coner.util.JacksonUtil;
-import org.coner.util.TestConstants;
-import org.eclipse.jetty.http.HttpStatus;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-
+import java.util.*;
 import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import java.util.ArrayList;
-import java.util.List;
+import javax.ws.rs.core.*;
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -31,15 +23,12 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-/**
- *
- */
 public class EventRegistrationsResourceTest {
 
     private final EventBoundary eventBoundary = mock(EventBoundary.class);
     private final RegistrationBoundary registrationBoundary = mock(RegistrationBoundary.class);
     private final ConerCoreService conerCoreService = mock(ConerCoreService.class);
-
+    
     private ObjectMapper objectMapper;
 
     @Rule
@@ -47,7 +36,6 @@ public class EventRegistrationsResourceTest {
             .addResource(new EventRegistrationsResource(eventBoundary, registrationBoundary, conerCoreService))
             .addProvider(new ConstraintViolationExceptionMapper())
             .build();
-
 
     @Before
     public void setup() {

--- a/dropwizard-app/src/test/java/org/coner/resource/EventResourceTest.java
+++ b/dropwizard-app/src/test/java/org/coner/resource/EventResourceTest.java
@@ -1,19 +1,14 @@
 package org.coner.resource;
 
-import io.dropwizard.testing.junit.ResourceTestRule;
 import org.coner.api.entity.Event;
 import org.coner.boundary.EventBoundary;
 import org.coner.core.ConerCoreService;
-import org.coner.util.ApiEntityTestUtils;
-import org.coner.util.DomainEntityTestUtils;
-import org.coner.util.TestConstants;
-import org.eclipse.jetty.http.HttpStatus;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.coner.util.*;
 
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import io.dropwizard.testing.junit.ResourceTestRule;
+import javax.ws.rs.core.*;
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -23,9 +18,6 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
-/**
- *
- */
 public class EventResourceTest {
 
     private final EventBoundary eventBoundary = mock(EventBoundary.class);

--- a/dropwizard-app/src/test/java/org/coner/resource/EventsResourceTest.java
+++ b/dropwizard-app/src/test/java/org/coner/resource/EventsResourceTest.java
@@ -1,28 +1,23 @@
 package org.coner.resource;
 
+import org.coner.api.response.*;
+import org.coner.boundary.EventBoundary;
+import org.coner.core.ConerCoreService;
+import org.coner.core.domain.Event;
+import org.coner.util.JacksonUtil;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.jackson.Jackson;
 import io.dropwizard.jersey.validation.ConstraintViolationExceptionMapper;
 import io.dropwizard.testing.FixtureHelpers;
 import io.dropwizard.testing.junit.ResourceTestRule;
-import org.coner.api.response.ErrorsResponse;
-import org.coner.api.response.GetEventsResponse;
-import org.coner.boundary.EventBoundary;
-import org.coner.core.ConerCoreService;
-import org.coner.core.domain.Event;
-import org.coner.util.JacksonUtil;
-import org.eclipse.jetty.http.HttpStatus;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 import java.sql.Date;
 import java.time.ZonedDateTime;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.*;
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.*;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.mockito.Mockito.any;
@@ -32,21 +27,16 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-/**
- *
- */
 public class EventsResourceTest {
 
     private final EventBoundary eventBoundary = mock(EventBoundary.class);
     private final ConerCoreService conerCoreService = mock(ConerCoreService.class);
-
-    private ObjectMapper objectMapper;
-
     @Rule
     public final ResourceTestRule resources = ResourceTestRule.builder()
             .addResource(new EventsResource(eventBoundary, conerCoreService))
             .addProvider(new ConstraintViolationExceptionMapper())
             .build();
+    private ObjectMapper objectMapper;
 
     @Before
     public void setup() {

--- a/dropwizard-app/src/test/java/org/coner/resource/HandicapGroupResourceTest.java
+++ b/dropwizard-app/src/test/java/org/coner/resource/HandicapGroupResourceTest.java
@@ -1,20 +1,15 @@
 package org.coner.resource;
 
-import io.dropwizard.jersey.validation.ConstraintViolationExceptionMapper;
-import io.dropwizard.testing.junit.ResourceTestRule;
 import org.coner.api.entity.HandicapGroup;
 import org.coner.boundary.HandicapGroupBoundary;
 import org.coner.core.ConerCoreService;
-import org.coner.util.ApiEntityTestUtils;
-import org.coner.util.DomainEntityTestUtils;
-import org.coner.util.TestConstants;
-import org.eclipse.jetty.http.HttpStatus;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.coner.util.*;
 
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import io.dropwizard.jersey.validation.ConstraintViolationExceptionMapper;
+import io.dropwizard.testing.junit.ResourceTestRule;
+import javax.ws.rs.core.*;
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -24,9 +19,6 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
-/**
- *
- */
 public class HandicapGroupResourceTest {
 
     private final HandicapGroupBoundary handicapGroupBoundary = mock(HandicapGroupBoundary.class);

--- a/dropwizard-app/src/test/java/org/coner/resource/HandicapGroupsResourceTest.java
+++ b/dropwizard-app/src/test/java/org/coner/resource/HandicapGroupsResourceTest.java
@@ -1,30 +1,21 @@
 package org.coner.resource;
 
+import org.coner.api.response.*;
+import org.coner.boundary.HandicapGroupBoundary;
+import org.coner.core.ConerCoreService;
+import org.coner.core.domain.HandicapGroup;
+import org.coner.util.*;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.jackson.Jackson;
 import io.dropwizard.jersey.validation.ConstraintViolationExceptionMapper;
 import io.dropwizard.testing.FixtureHelpers;
 import io.dropwizard.testing.junit.ResourceTestRule;
-import org.coner.api.response.ErrorsResponse;
-import org.coner.api.response.GetHandicapGroupsResponse;
-import org.coner.boundary.HandicapGroupBoundary;
-import org.coner.core.ConerCoreService;
-import org.coner.core.domain.HandicapGroup;
-import org.coner.util.ApiEntityTestUtils;
-import org.coner.util.DomainEntityTestUtils;
-import org.coner.util.JacksonUtil;
-import org.coner.util.TestConstants;
-import org.coner.util.UnitTestUtils;
-import org.eclipse.jetty.http.HttpStatus;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-
+import java.util.*;
 import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import java.util.ArrayList;
-import java.util.List;
+import javax.ws.rs.core.*;
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.*;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.mockito.Matchers.any;
@@ -35,20 +26,15 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-/**
- *
- */
 public class HandicapGroupsResourceTest {
     private final HandicapGroupBoundary handicapGroupBoundary = mock(HandicapGroupBoundary.class);
     private final ConerCoreService conerCoreService = mock(ConerCoreService.class);
-
-    private ObjectMapper objectMapper;
-
     @Rule
     public final ResourceTestRule resources = ResourceTestRule.builder()
             .addResource(new HandicapGroupsResource(handicapGroupBoundary, conerCoreService))
             .addProvider(new ConstraintViolationExceptionMapper())
             .build();
+    private ObjectMapper objectMapper;
 
     @Before
     public void setup() {

--- a/dropwizard-app/src/test/java/org/coner/util/ApiEntityTestUtils.java
+++ b/dropwizard-app/src/test/java/org/coner/util/ApiEntityTestUtils.java
@@ -1,25 +1,16 @@
 package org.coner.util;
 
+import org.coner.api.entity.*;
+
 import com.google.common.collect.Sets;
-import org.coner.api.entity.CompetitionGroup;
-import org.coner.api.entity.CompetitionGroupSet;
-import org.coner.api.entity.Event;
-import org.coner.api.entity.HandicapGroup;
-import org.coner.api.entity.Registration;
-
 import java.math.BigDecimal;
-import java.util.Date;
-import java.util.Set;
+import java.util.*;
 
-/**
- *
- */
 public final class ApiEntityTestUtils {
 
     private ApiEntityTestUtils() {
     }
 
-    // Event
     public static Event fullApiEvent() {
         return fullApiEvent(TestConstants.EVENT_ID, TestConstants.EVENT_NAME, TestConstants.EVENT_DATE);
     }
@@ -32,7 +23,6 @@ public final class ApiEntityTestUtils {
         return apiEvent;
     }
 
-    // Registration
     public static Registration fullApiRegistration() {
         return fullApiRegistration(TestConstants.REGISTRATION_ID, TestConstants.REGISTRATION_FIRSTNAME,
                 TestConstants.REGISTRATION_LASTNAME);
@@ -47,7 +37,6 @@ public final class ApiEntityTestUtils {
         return apiRegistration;
     }
 
-    // HandicapGroup
     public static HandicapGroup fullHandicapGroup() {
         return fullHandicapGroup(
                 TestConstants.HANDICAP_GROUP_ID,
@@ -66,7 +55,6 @@ public final class ApiEntityTestUtils {
         return apiHandicapGroup;
     }
 
-    // CompetitionGroup
     public static CompetitionGroup fullCompetitionGroup() {
         return fullCompetitionGroup(
                 TestConstants.COMPETITION_GROUP_ID,

--- a/dropwizard-app/src/test/java/org/coner/util/DomainEntityTestUtils.java
+++ b/dropwizard-app/src/test/java/org/coner/util/DomainEntityTestUtils.java
@@ -1,25 +1,16 @@
 package org.coner.util;
 
+import org.coner.core.domain.*;
+
 import com.google.common.collect.Sets;
-import org.coner.core.domain.CompetitionGroup;
-import org.coner.core.domain.CompetitionGroupSet;
-import org.coner.core.domain.Event;
-import org.coner.core.domain.HandicapGroup;
-import org.coner.core.domain.Registration;
-
 import java.math.BigDecimal;
-import java.util.Date;
-import java.util.Set;
+import java.util.*;
 
-/**
- *
- */
 public final class DomainEntityTestUtils {
 
     private DomainEntityTestUtils() {
     }
 
-    // Event
     public static Event fullDomainEvent() {
         return fullDomainEvent(TestConstants.EVENT_ID, TestConstants.EVENT_NAME, TestConstants.EVENT_DATE);
     }
@@ -32,7 +23,6 @@ public final class DomainEntityTestUtils {
         return domainEvent;
     }
 
-    // Registration
     public static Registration fullDomainRegistration() {
         return fullDomainRegistration(TestConstants.REGISTRATION_ID, TestConstants.REGISTRATION_FIRSTNAME,
                 TestConstants.REGISTRATION_LASTNAME);
@@ -48,7 +38,6 @@ public final class DomainEntityTestUtils {
         return domainRegistration;
     }
 
-    // HandicapGroup
     public static HandicapGroup fullHandicapGroup() {
         return fullHandicapGroup(
                 TestConstants.HANDICAP_GROUP_ID,

--- a/dropwizard-app/src/test/java/org/coner/util/TestConstants.java
+++ b/dropwizard-app/src/test/java/org/coner/util/TestConstants.java
@@ -6,9 +6,6 @@ import java.math.BigDecimal;
 import java.time.ZonedDateTime;
 import java.util.Date;
 
-/**
- *
- */
 public final class TestConstants {
 
     private TestConstants() {
@@ -17,18 +14,18 @@ public final class TestConstants {
     // Event
     public static final String EVENT_ID = "event-test-id";
     public static final String EVENT_NAME = "event-test-name";
-    public static final Date EVENT_DATE = Date.from(ZonedDateTime.parse("2014-12-26T19:44:00-05:00").toInstant());
 
+    public static final Date EVENT_DATE = Date.from(ZonedDateTime.parse("2014-12-26T19:44:00-05:00").toInstant());
     //Registration
     public static final String REGISTRATION_ID = "registration-test-id";
     public static final String REGISTRATION_FIRSTNAME = "registration-firstname";
-    public static final String REGISTRATION_LASTNAME = "registration-lastname";
 
+    public static final String REGISTRATION_LASTNAME = "registration-lastname";
     //HandicapGroup
     public static final String HANDICAP_GROUP_ID = "handicap-group-test-id";
     public static final String HANDICAP_GROUP_NAME = "handicap-group-name";
-    public static final BigDecimal HANDICAP_GROUP_FACTOR = BigDecimal.valueOf(0.75);
 
+    public static final BigDecimal HANDICAP_GROUP_FACTOR = BigDecimal.valueOf(0.75);
     // CompetitionGroup
     public static final String COMPETITION_GROUP_ID = "competition-group-test-id";
     public static final String COMPETITION_GROUP_NAME = "competition-group-name";

--- a/dropwizard-app/src/test/java/org/coner/util/UnitTestUtils.java
+++ b/dropwizard-app/src/test/java/org/coner/util/UnitTestUtils.java
@@ -1,8 +1,7 @@
 package org.coner.util;
 
-import org.apache.commons.lang3.StringUtils;
-
 import javax.ws.rs.core.Response;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  *

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <version>2.13</version>
                 <configuration>
-                    <configLocation>checkstyle/checkstyle.xml</configLocation>
+                    <configLocation>build-tools/src/main/resources/checkstyle/checkstyle.xml</configLocation>
                     <includeTestSourceDirectory>true</includeTestSourceDirectory>
                     <suppressionsLocation>checkstyle/suppressions.xml</suppressionsLocation>
                     <linkXRef>false</linkXRef>
@@ -77,7 +77,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <version>2.13</version>
                 <configuration>
-                    <configLocation>checkstyle/checkstyle.xml</configLocation>
+                    <configLocation>build-tools/src/main/resources/checkstyle/checkstyle.xml</configLocation>
                     <linkXRef>false</linkXRef>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Checkstyle changes:
- Removed Javadoc modules that were mandating pointless comments
- Removed AvoidStarImports to shorten import lists and make it easier to
work at the correct level of abstraction
- Added ImportOrder to enforce sorting, and separate grouping of the
org.coner package
- Changed configLocation to correct path