### PR TITLE
Rename API and Hibernate entity classes

### DIFF
--- a/dropwizard-api/src/main/java/org/coner/api/entity/CompetitionGroupApiEntity.java
+++ b/dropwizard-api/src/main/java/org/coner/api/entity/CompetitionGroupApiEntity.java
@@ -6,7 +6,7 @@ import javax.validation.constraints.*;
 import org.hibernate.validator.constraints.NotBlank;
 
 @JsonPropertyOrder({"id", "name", "handicapFactor", "grouping", "resultTimeType"})
-public class CompetitionGroup extends ApiEntity {
+public class CompetitionGroupApiEntity extends ApiEntity {
 
     @Null(message = "competitionGroup.id may only be assigned by the system")
     private String id;
@@ -66,7 +66,7 @@ public class CompetitionGroup extends ApiEntity {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
 
-        CompetitionGroup that = (CompetitionGroup) o;
+        CompetitionGroupApiEntity that = (CompetitionGroupApiEntity) o;
 
         if (grouping != null ? !grouping.equals(that.grouping) : that.grouping != null) return false;
         if (handicapFactor != null ? !handicapFactor.equals(that.handicapFactor) : that.handicapFactor != null)

--- a/dropwizard-api/src/main/java/org/coner/api/entity/CompetitionGroupSet.java
+++ b/dropwizard-api/src/main/java/org/coner/api/entity/CompetitionGroupSet.java
@@ -8,7 +8,7 @@ public class CompetitionGroupSet extends ApiEntity {
 
     private String id;
     private String name;
-    private Set<CompetitionGroup> competitionGroups;
+    private Set<CompetitionGroupApiEntity> competitionGroups;
 
     public String getId() {
         return id;
@@ -26,11 +26,11 @@ public class CompetitionGroupSet extends ApiEntity {
         this.name = name;
     }
 
-    public Set<CompetitionGroup> getCompetitionGroups() {
+    public Set<CompetitionGroupApiEntity> getCompetitionGroups() {
         return competitionGroups;
     }
 
-    public void setCompetitionGroups(Set<CompetitionGroup> competitionGroups) {
+    public void setCompetitionGroups(Set<CompetitionGroupApiEntity> competitionGroups) {
         this.competitionGroups = competitionGroups;
     }
 }

--- a/dropwizard-api/src/main/java/org/coner/api/entity/CompetitionGroupSetApiEntity.java
+++ b/dropwizard-api/src/main/java/org/coner/api/entity/CompetitionGroupSetApiEntity.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.util.Set;
 
 @JsonPropertyOrder({"id", "name", "competitionGroups"})
-public class CompetitionGroupSet extends ApiEntity {
+public class CompetitionGroupSetApiEntity extends ApiEntity {
 
     private String id;
     private String name;

--- a/dropwizard-api/src/main/java/org/coner/api/entity/EventApiEntity.java
+++ b/dropwizard-api/src/main/java/org/coner/api/entity/EventApiEntity.java
@@ -1,27 +1,20 @@
-package org.coner.hibernate.entity;
+package org.coner.api.entity;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.util.Date;
-import javax.persistence.*;
-import org.hibernate.annotations.GenericGenerator;
+import javax.validation.constraints.*;
+import org.hibernate.validator.constraints.NotBlank;
 
-@Entity
-@Table(name = "events")
-@NamedQueries({
-        @NamedQuery(
-                name = Event.QUERY_FIND_ALL,
-                query = "from Event"
-        )
-})
-public class Event extends HibernateEntity {
+@JsonPropertyOrder({"id", "name", "date"})
+public class EventApiEntity extends ApiEntity {
 
-    public static final String QUERY_FIND_ALL = "org.coner.hibernate.entity.Event.findAll";
+    @Null(message = "event.id may only be assigned by the system")
     private String id;
+    @NotBlank
     private String name;
+    @NotNull
     private Date date;
 
-    @Id
-    @GeneratedValue(generator = "uuid")
-    @GenericGenerator(name = "uuid", strategy = "uuid2")
     public String getId() {
         return id;
     }
@@ -30,7 +23,6 @@ public class Event extends HibernateEntity {
         this.id = id;
     }
 
-    @Column(name = "name")
     public String getName() {
         return name;
     }
@@ -39,8 +31,6 @@ public class Event extends HibernateEntity {
         this.name = name;
     }
 
-    @Temporal(TemporalType.TIMESTAMP)
-    @Column(name = "date")
     public Date getDate() {
         return date;
     }
@@ -54,9 +44,9 @@ public class Event extends HibernateEntity {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
 
-        Event event = (Event) o;
+        EventApiEntity event = (EventApiEntity) o;
 
-        if (date != null ? !(date.compareTo(event.date) == 0) : event.date != null) return false;
+        if (date != null ? !date.equals(event.date) : event.date != null) return false;
         if (id != null ? !id.equals(event.id) : event.id != null) return false;
         if (name != null ? !name.equals(event.name) : event.name != null) return false;
 

--- a/dropwizard-api/src/main/java/org/coner/api/entity/HandicapGroupApiEntity.java
+++ b/dropwizard-api/src/main/java/org/coner/api/entity/HandicapGroupApiEntity.java
@@ -5,7 +5,7 @@ import java.math.BigDecimal;
 import javax.validation.constraints.*;
 
 @JsonPropertyOrder({"id", "name", "handicapFactor"})
-public class HandicapGroup extends ApiEntity {
+public class HandicapGroupApiEntity extends ApiEntity {
 
     @Null(message = "handicapGroup.id may only be assigned by the system")
     private String id;
@@ -45,7 +45,7 @@ public class HandicapGroup extends ApiEntity {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
 
-        HandicapGroup that = (HandicapGroup) o;
+        HandicapGroupApiEntity that = (HandicapGroupApiEntity) o;
 
         if (handicapFactor != null ? !handicapFactor.equals(that.handicapFactor) : that.handicapFactor != null)
             return false;

--- a/dropwizard-api/src/main/java/org/coner/api/entity/HandicapGroupSet.java
+++ b/dropwizard-api/src/main/java/org/coner/api/entity/HandicapGroupSet.java
@@ -12,7 +12,7 @@ public class HandicapGroupSet extends ApiEntity {
 
     private String id;
     private String name;
-    private Set<HandicapGroup> handicapGroups;
+    private Set<HandicapGroupApiEntity> handicapGroups;
 
     public String getId() {
         return id;
@@ -30,11 +30,11 @@ public class HandicapGroupSet extends ApiEntity {
         this.name = name;
     }
 
-    public Set<HandicapGroup> getHandicapGroups() {
+    public Set<HandicapGroupApiEntity> getHandicapGroups() {
         return handicapGroups;
     }
 
-    public void setHandicapGroups(Set<HandicapGroup> handicapGroups) {
+    public void setHandicapGroups(Set<HandicapGroupApiEntity> handicapGroups) {
         this.handicapGroups = handicapGroups;
     }
 }

--- a/dropwizard-api/src/main/java/org/coner/api/entity/HandicapGroupSetApiEntity.java
+++ b/dropwizard-api/src/main/java/org/coner/api/entity/HandicapGroupSetApiEntity.java
@@ -1,14 +1,10 @@
 package org.coner.api.entity;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-
 import java.util.Set;
 
-/**
- * REST API entity representing a Handicap Group Set
- */
 @JsonPropertyOrder({"id", "name", "handicapGroups"})
-public class HandicapGroupSet extends ApiEntity {
+public class HandicapGroupSetApiEntity extends ApiEntity {
 
     private String id;
     private String name;

--- a/dropwizard-api/src/main/java/org/coner/api/entity/RegistrationApiEntity.java
+++ b/dropwizard-api/src/main/java/org/coner/api/entity/RegistrationApiEntity.java
@@ -5,7 +5,7 @@ import javax.validation.constraints.*;
 import org.hibernate.validator.constraints.NotBlank;
 
 @JsonPropertyOrder({"id", "firstName", "lastName", "event"})
-public class Registration extends ApiEntity {
+public class RegistrationApiEntity extends ApiEntity {
 
     @Null(message = "registration.id may only be assigned by the system")
     private String id;
@@ -43,7 +43,7 @@ public class Registration extends ApiEntity {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
 
-        Registration that = (Registration) o;
+        RegistrationApiEntity that = (RegistrationApiEntity) o;
 
         if (firstName != null ? !firstName.equals(that.firstName) : that.firstName != null) return false;
         if (id != null ? !id.equals(that.id) : that.id != null) return false;

--- a/dropwizard-api/src/main/java/org/coner/api/request/AddCompetitionGroupRequest.java
+++ b/dropwizard-api/src/main/java/org/coner/api/request/AddCompetitionGroupRequest.java
@@ -1,6 +1,6 @@
 package org.coner.api.request;
 
-import org.coner.api.entity.CompetitionGroup;
+import org.coner.api.entity.CompetitionGroupApiEntity;
 
-public class AddCompetitionGroupRequest extends CompetitionGroup {
+public class AddCompetitionGroupRequest extends CompetitionGroupApiEntity {
 }

--- a/dropwizard-api/src/main/java/org/coner/api/request/AddEventRequest.java
+++ b/dropwizard-api/src/main/java/org/coner/api/request/AddEventRequest.java
@@ -1,7 +1,7 @@
 package org.coner.api.request;
 
-import org.coner.api.entity.Event;
+import org.coner.api.entity.EventApiEntity;
 
-public class AddEventRequest extends Event {
+public class AddEventRequest extends EventApiEntity {
 
 }

--- a/dropwizard-api/src/main/java/org/coner/api/request/AddHandicapGroupRequest.java
+++ b/dropwizard-api/src/main/java/org/coner/api/request/AddHandicapGroupRequest.java
@@ -1,6 +1,6 @@
 package org.coner.api.request;
 
-import org.coner.api.entity.HandicapGroup;
+import org.coner.api.entity.HandicapGroupApiEntity;
 
-public class AddHandicapGroupRequest extends HandicapGroup {
+public class AddHandicapGroupRequest extends HandicapGroupApiEntity {
 }

--- a/dropwizard-api/src/main/java/org/coner/api/request/AddRegistrationRequest.java
+++ b/dropwizard-api/src/main/java/org/coner/api/request/AddRegistrationRequest.java
@@ -1,6 +1,6 @@
 package org.coner.api.request;
 
-import org.coner.api.entity.Registration;
+import org.coner.api.entity.RegistrationApiEntity;
 
-public class AddRegistrationRequest extends Registration {
+public class AddRegistrationRequest extends RegistrationApiEntity {
 }

--- a/dropwizard-api/src/main/java/org/coner/api/response/GetCompetitionGroupsResponse.java
+++ b/dropwizard-api/src/main/java/org/coner/api/response/GetCompetitionGroupsResponse.java
@@ -1,17 +1,17 @@
 package org.coner.api.response;
 
-import org.coner.api.entity.CompetitionGroup;
+import org.coner.api.entity.CompetitionGroupApiEntity;
 
 import java.util.List;
 
 public class GetCompetitionGroupsResponse {
-    private List<CompetitionGroup> competitionGroups;
+    private List<CompetitionGroupApiEntity> competitionGroups;
 
-    public List<CompetitionGroup> getCompetitionGroups() {
+    public List<CompetitionGroupApiEntity> getCompetitionGroups() {
         return competitionGroups;
     }
 
-    public void setCompetitionGroups(List<CompetitionGroup> competitionGroups) {
+    public void setCompetitionGroups(List<CompetitionGroupApiEntity> competitionGroups) {
         this.competitionGroups = competitionGroups;
     }
 }

--- a/dropwizard-api/src/main/java/org/coner/api/response/GetEventRegistrationsResponse.java
+++ b/dropwizard-api/src/main/java/org/coner/api/response/GetEventRegistrationsResponse.java
@@ -1,18 +1,18 @@
 package org.coner.api.response;
 
-import org.coner.api.entity.Registration;
+import org.coner.api.entity.RegistrationApiEntity;
 
 import java.util.List;
 
 public class GetEventRegistrationsResponse {
 
-    private List<Registration> registrations;
+    private List<RegistrationApiEntity> registrations;
 
-    public List<Registration> getRegistrations() {
+    public List<RegistrationApiEntity> getRegistrations() {
         return registrations;
     }
 
-    public void setRegistrations(List<Registration> registrations) {
+    public void setRegistrations(List<RegistrationApiEntity> registrations) {
         this.registrations = registrations;
     }
 }

--- a/dropwizard-api/src/main/java/org/coner/api/response/GetEventsResponse.java
+++ b/dropwizard-api/src/main/java/org/coner/api/response/GetEventsResponse.java
@@ -1,19 +1,19 @@
 package org.coner.api.response;
 
 
-import org.coner.api.entity.Event;
+import org.coner.api.entity.EventApiEntity;
 
 import java.util.List;
 
 public class GetEventsResponse {
 
-    private List<Event> events;
+    private List<EventApiEntity> events;
 
-    public List<Event> getEvents() {
+    public List<EventApiEntity> getEvents() {
         return events;
     }
 
-    public void setEvents(List<Event> events) {
+    public void setEvents(List<EventApiEntity> events) {
         this.events = events;
     }
 }

--- a/dropwizard-api/src/main/java/org/coner/api/response/GetHandicapGroupsResponse.java
+++ b/dropwizard-api/src/main/java/org/coner/api/response/GetHandicapGroupsResponse.java
@@ -1,17 +1,17 @@
 package org.coner.api.response;
 
-import org.coner.api.entity.HandicapGroup;
+import org.coner.api.entity.HandicapGroupApiEntity;
 
 import java.util.List;
 
 public class GetHandicapGroupsResponse {
-    private List<HandicapGroup> handicapGroups;
+    private List<HandicapGroupApiEntity> handicapGroups;
 
-    public List<HandicapGroup> getHandicapGroups() {
+    public List<HandicapGroupApiEntity> getHandicapGroups() {
         return handicapGroups;
     }
 
-    public void setHandicapGroups(List<HandicapGroup> handicapGroups) {
+    public void setHandicapGroups(List<HandicapGroupApiEntity> handicapGroups) {
         this.handicapGroups = handicapGroups;
     }
 }

--- a/dropwizard-app/src/main/java/org/coner/ConerDropwizardApplication.java
+++ b/dropwizard-app/src/main/java/org/coner/ConerDropwizardApplication.java
@@ -134,7 +134,7 @@ public class ConerDropwizardApplication extends Application<ConerDropwizardConfi
     private HibernateBundle<ConerDropwizardConfiguration> getHibernate() {
         if (hibernate == null) {
             hibernate = new HibernateBundle<ConerDropwizardConfiguration>(
-                    Event.class,
+                    EventHibernateEntity.class,
                     RegistrationHibernateEntity.class,
                     HandicapGroupHibernateEntity.class,
                     HandicapGroupSetHibernateEntity.class,

--- a/dropwizard-app/src/main/java/org/coner/ConerDropwizardApplication.java
+++ b/dropwizard-app/src/main/java/org/coner/ConerDropwizardApplication.java
@@ -137,7 +137,7 @@ public class ConerDropwizardApplication extends Application<ConerDropwizardConfi
                     Event.class,
                     Registration.class,
                     HandicapGroupHibernateEntity.class,
-                    HandicapGroupSet.class,
+                    HandicapGroupSetHibernateEntity.class,
                     CompetitionGroupHibernateEntity.class,
                     CompetitionGroupSetHibernateEntity.class
             ) {

--- a/dropwizard-app/src/main/java/org/coner/ConerDropwizardApplication.java
+++ b/dropwizard-app/src/main/java/org/coner/ConerDropwizardApplication.java
@@ -135,7 +135,7 @@ public class ConerDropwizardApplication extends Application<ConerDropwizardConfi
         if (hibernate == null) {
             hibernate = new HibernateBundle<ConerDropwizardConfiguration>(
                     Event.class,
-                    Registration.class,
+                    RegistrationHibernateEntity.class,
                     HandicapGroupHibernateEntity.class,
                     HandicapGroupSetHibernateEntity.class,
                     CompetitionGroupHibernateEntity.class,

--- a/dropwizard-app/src/main/java/org/coner/ConerDropwizardApplication.java
+++ b/dropwizard-app/src/main/java/org/coner/ConerDropwizardApplication.java
@@ -138,7 +138,7 @@ public class ConerDropwizardApplication extends Application<ConerDropwizardConfi
                     Registration.class,
                     HandicapGroup.class,
                     HandicapGroupSet.class,
-                    CompetitionGroup.class,
+                    CompetitionGroupHibernateEntity.class,
                     CompetitionGroupSet.class
             ) {
                 @Override

--- a/dropwizard-app/src/main/java/org/coner/ConerDropwizardApplication.java
+++ b/dropwizard-app/src/main/java/org/coner/ConerDropwizardApplication.java
@@ -136,7 +136,7 @@ public class ConerDropwizardApplication extends Application<ConerDropwizardConfi
             hibernate = new HibernateBundle<ConerDropwizardConfiguration>(
                     Event.class,
                     Registration.class,
-                    HandicapGroup.class,
+                    HandicapGroupHibernateEntity.class,
                     HandicapGroupSet.class,
                     CompetitionGroupHibernateEntity.class,
                     CompetitionGroupSetHibernateEntity.class

--- a/dropwizard-app/src/main/java/org/coner/ConerDropwizardApplication.java
+++ b/dropwizard-app/src/main/java/org/coner/ConerDropwizardApplication.java
@@ -139,7 +139,7 @@ public class ConerDropwizardApplication extends Application<ConerDropwizardConfi
                     HandicapGroup.class,
                     HandicapGroupSet.class,
                     CompetitionGroupHibernateEntity.class,
-                    CompetitionGroupSet.class
+                    CompetitionGroupSetHibernateEntity.class
             ) {
                 @Override
                 public DataSourceFactory getDataSourceFactory(

--- a/dropwizard-app/src/main/java/org/coner/boundary/CompetitionGroupBoundary.java
+++ b/dropwizard-app/src/main/java/org/coner/boundary/CompetitionGroupBoundary.java
@@ -1,30 +1,32 @@
 package org.coner.boundary;
 
+import org.coner.api.entity.CompetitionGroupApiEntity;
 import org.coner.core.domain.CompetitionGroup;
+import org.coner.hibernate.entity.CompetitionGroupHibernateEntity;
 
 public class CompetitionGroupBoundary extends AbstractBoundary<
-        org.coner.api.entity.CompetitionGroup,
+        CompetitionGroupApiEntity,
         CompetitionGroup,
-        org.coner.hibernate.entity.CompetitionGroup> {
+        CompetitionGroupHibernateEntity> {
 
     @Override
-    protected EntityMerger<org.coner.api.entity.CompetitionGroup, CompetitionGroup> buildApiToDomainMerger() {
+    protected EntityMerger<CompetitionGroupApiEntity, CompetitionGroup> buildApiToDomainMerger() {
         return new ReflectionEntityMerger<>();
     }
 
     @Override
-    protected EntityMerger<CompetitionGroup, org.coner.api.entity.CompetitionGroup> buildDomainToApiMerger() {
+    protected EntityMerger<CompetitionGroup, CompetitionGroupApiEntity> buildDomainToApiMerger() {
         return new ReflectionEntityMerger<>();
     }
 
     @Override
     protected EntityMerger<CompetitionGroup,
-            org.coner.hibernate.entity.CompetitionGroup> buildDomainToHibernateMerger() {
+            CompetitionGroupHibernateEntity> buildDomainToHibernateMerger() {
         return new ReflectionEntityMerger<>();
     }
 
     @Override
-    protected EntityMerger<org.coner.hibernate.entity.CompetitionGroup,
+    protected EntityMerger<CompetitionGroupHibernateEntity,
             CompetitionGroup> buildHibernateToDomainMerger() {
         return new ReflectionEntityMerger<>();
     }

--- a/dropwizard-app/src/main/java/org/coner/boundary/CompetitionGroupSetBoundary.java
+++ b/dropwizard-app/src/main/java/org/coner/boundary/CompetitionGroupSetBoundary.java
@@ -1,19 +1,21 @@
 package org.coner.boundary;
 
+import org.coner.api.entity.CompetitionGroupSetApiEntity;
 import org.coner.api.request.AddCompetitionGroupSetRequest;
 import org.coner.core.domain.CompetitionGroupSet;
+import org.coner.hibernate.entity.CompetitionGroupSetHibernateEntity;
 
 public class CompetitionGroupSetBoundary extends AbstractBoundary<
-        org.coner.api.entity.CompetitionGroupSet,
+        CompetitionGroupSetApiEntity,
         CompetitionGroupSet,
-        org.coner.hibernate.entity.CompetitionGroupSet
+        CompetitionGroupSetHibernateEntity
         > {
 
     private EntityMerger<org.coner.api.request.AddCompetitionGroupSetRequest, CompetitionGroupSet>
             apiAddCompetitionGroupSetRequestToDomainCompetitionGroupSetEntityMerger;
 
     @Override
-    protected EntityMerger<org.coner.api.entity.CompetitionGroupSet, CompetitionGroupSet> buildApiToDomainMerger() {
+    protected EntityMerger<CompetitionGroupSetApiEntity, CompetitionGroupSet> buildApiToDomainMerger() {
         return new ReflectionEntityMerger<>();
     }
 
@@ -30,12 +32,12 @@ public class CompetitionGroupSetBoundary extends AbstractBoundary<
     }
 
     @Override
-    protected EntityMerger<CompetitionGroupSet, org.coner.api.entity.CompetitionGroupSet> buildDomainToApiMerger() {
+    protected EntityMerger<CompetitionGroupSet, CompetitionGroupSetApiEntity> buildDomainToApiMerger() {
         return new ReflectionEntityMerger<>();
     }
 
     @Override
-    protected EntityMerger<CompetitionGroupSet, org.coner.hibernate.entity.CompetitionGroupSet>
+    protected EntityMerger<CompetitionGroupSet, CompetitionGroupSetHibernateEntity>
     buildDomainToHibernateMerger() {
         return new ReflectionEntityMerger<>((source, destination) -> {
             destination.setCompetitionGroupSetId(source.getId());
@@ -43,7 +45,7 @@ public class CompetitionGroupSetBoundary extends AbstractBoundary<
     }
 
     @Override
-    protected EntityMerger<org.coner.hibernate.entity.CompetitionGroupSet, CompetitionGroupSet>
+    protected EntityMerger<CompetitionGroupSetHibernateEntity, CompetitionGroupSet>
     buildHibernateToDomainMerger() {
         return new ReflectionEntityMerger<>((source, destination) -> {
             destination.setId(source.getCompetitionGroupSetId());

--- a/dropwizard-app/src/main/java/org/coner/boundary/EventBoundary.java
+++ b/dropwizard-app/src/main/java/org/coner/boundary/EventBoundary.java
@@ -1,29 +1,28 @@
 package org.coner.boundary;
 
+import org.coner.api.entity.EventApiEntity;
 import org.coner.core.domain.Event;
+import org.coner.hibernate.entity.EventHibernateEntity;
 
-public class EventBoundary extends AbstractBoundary<
-        org.coner.api.entity.Event,
-        Event,
-        org.coner.hibernate.entity.Event> {
+public class EventBoundary extends AbstractBoundary<EventApiEntity, Event, EventHibernateEntity> {
 
     @Override
-    protected EntityMerger<org.coner.api.entity.Event, Event> buildApiToDomainMerger() {
+    protected EntityMerger<EventApiEntity, Event> buildApiToDomainMerger() {
         return new ReflectionEntityMerger<>();
     }
 
     @Override
-    protected EntityMerger<Event, org.coner.api.entity.Event> buildDomainToApiMerger() {
+    protected EntityMerger<Event, EventApiEntity> buildDomainToApiMerger() {
         return new ReflectionEntityMerger<>();
     }
 
     @Override
-    protected EntityMerger<Event, org.coner.hibernate.entity.Event> buildDomainToHibernateMerger() {
+    protected EntityMerger<Event, EventHibernateEntity> buildDomainToHibernateMerger() {
         return new ReflectionEntityMerger<>();
     }
 
     @Override
-    protected EntityMerger<org.coner.hibernate.entity.Event, Event> buildHibernateToDomainMerger() {
+    protected EntityMerger<EventHibernateEntity, Event> buildHibernateToDomainMerger() {
         return new ReflectionEntityMerger<>();
     }
 }

--- a/dropwizard-app/src/main/java/org/coner/boundary/HandicapGroupBoundary.java
+++ b/dropwizard-app/src/main/java/org/coner/boundary/HandicapGroupBoundary.java
@@ -1,29 +1,31 @@
 package org.coner.boundary;
 
+import org.coner.api.entity.HandicapGroupApiEntity;
 import org.coner.core.domain.HandicapGroup;
+import org.coner.hibernate.entity.HandicapGroupHibernateEntity;
 
 public class HandicapGroupBoundary extends AbstractBoundary<
-        org.coner.api.entity.HandicapGroup,
+        HandicapGroupApiEntity,
         HandicapGroup,
-        org.coner.hibernate.entity.HandicapGroup> {
+        HandicapGroupHibernateEntity> {
 
     @Override
-    protected EntityMerger<org.coner.api.entity.HandicapGroup, HandicapGroup> buildApiToDomainMerger() {
+    protected EntityMerger<HandicapGroupApiEntity, HandicapGroup> buildApiToDomainMerger() {
         return new ReflectionEntityMerger<>();
     }
 
     @Override
-    protected EntityMerger<HandicapGroup, org.coner.api.entity.HandicapGroup> buildDomainToApiMerger() {
+    protected EntityMerger<HandicapGroup, HandicapGroupApiEntity> buildDomainToApiMerger() {
         return new ReflectionEntityMerger<>();
     }
 
     @Override
-    protected EntityMerger<HandicapGroup, org.coner.hibernate.entity.HandicapGroup> buildDomainToHibernateMerger() {
+    protected EntityMerger<HandicapGroup, HandicapGroupHibernateEntity> buildDomainToHibernateMerger() {
         return new ReflectionEntityMerger<>();
     }
 
     @Override
-    protected EntityMerger<org.coner.hibernate.entity.HandicapGroup, HandicapGroup> buildHibernateToDomainMerger() {
+    protected EntityMerger<HandicapGroupHibernateEntity, HandicapGroup> buildHibernateToDomainMerger() {
         return new ReflectionEntityMerger<>();
     }
 }

--- a/dropwizard-app/src/main/java/org/coner/boundary/HandicapGroupSetBoundary.java
+++ b/dropwizard-app/src/main/java/org/coner/boundary/HandicapGroupSetBoundary.java
@@ -1,30 +1,23 @@
 package org.coner.boundary;
 
+import org.coner.api.entity.HandicapGroupSetApiEntity;
 import org.coner.api.request.AddHandicapGroupSetRequest;
 import org.coner.core.domain.HandicapGroupSet;
+import org.coner.hibernate.entity.HandicapGroupSetHibernateEntity;
 
-/**
- * Converts HandicapGroupSet entities as they cross architectural boundaries
- */
 public class HandicapGroupSetBoundary extends AbstractBoundary<
-        org.coner.api.entity.HandicapGroupSet,
+        HandicapGroupSetApiEntity,
         HandicapGroupSet,
-        org.coner.hibernate.entity.HandicapGroupSet> {
+        HandicapGroupSetHibernateEntity> {
 
-    private EntityMerger<org.coner.api.request.AddHandicapGroupSetRequest, HandicapGroupSet>
+    private EntityMerger<AddHandicapGroupSetRequest, HandicapGroupSet>
             apiAddHandicapGroupSetRequestToDomainHandicapGroupSetEntityMerger;
 
     @Override
-    protected EntityMerger<org.coner.api.entity.HandicapGroupSet, HandicapGroupSet> buildApiToDomainMerger() {
+    protected EntityMerger<HandicapGroupSetApiEntity, HandicapGroupSet> buildApiToDomainMerger() {
         return new ReflectionEntityMerger<>();
     }
 
-    /**
-     * Convert an API AddHandicapGroupSetRequest to a domain HandicapGroupSet
-     *
-     * @param addHandicapGroupSetRequest API request to convert
-     * @return a HandicapGroupSet entity
-     */
     public HandicapGroupSet toDomainEntity(AddHandicapGroupSetRequest addHandicapGroupSetRequest) {
         if (apiAddHandicapGroupSetRequestToDomainHandicapGroupSetEntityMerger == null) {
             apiAddHandicapGroupSetRequestToDomainHandicapGroupSetEntityMerger = new ReflectionEntityMerger<>();
@@ -38,12 +31,12 @@ public class HandicapGroupSetBoundary extends AbstractBoundary<
     }
 
     @Override
-    protected EntityMerger<HandicapGroupSet, org.coner.api.entity.HandicapGroupSet> buildDomainToApiMerger() {
+    protected EntityMerger<HandicapGroupSet, HandicapGroupSetApiEntity> buildDomainToApiMerger() {
         return new ReflectionEntityMerger<>();
     }
 
     @Override
-    protected EntityMerger<HandicapGroupSet, org.coner.hibernate.entity.HandicapGroupSet>
+    protected EntityMerger<HandicapGroupSet, HandicapGroupSetHibernateEntity>
     buildDomainToHibernateMerger() {
         return new ReflectionEntityMerger<>((source, destination) -> {
             destination.setHandicapGroupSetId(source.getId());
@@ -51,7 +44,7 @@ public class HandicapGroupSetBoundary extends AbstractBoundary<
     }
 
     @Override
-    protected EntityMerger<org.coner.hibernate.entity.HandicapGroupSet, HandicapGroupSet>
+    protected EntityMerger<HandicapGroupSetHibernateEntity, HandicapGroupSet>
     buildHibernateToDomainMerger() {
         return new ReflectionEntityMerger<>((source, destination) -> {
             destination.setId(source.getHandicapGroupSetId());

--- a/dropwizard-app/src/main/java/org/coner/boundary/RegistrationBoundary.java
+++ b/dropwizard-app/src/main/java/org/coner/boundary/RegistrationBoundary.java
@@ -1,11 +1,13 @@
 package org.coner.boundary;
 
+import org.coner.api.entity.RegistrationApiEntity;
 import org.coner.core.domain.Registration;
+import org.coner.hibernate.entity.RegistrationHibernateEntity;
 
 public class RegistrationBoundary extends AbstractBoundary<
-        org.coner.api.entity.Registration,
+        RegistrationApiEntity,
         Registration,
-        org.coner.hibernate.entity.Registration> {
+        RegistrationHibernateEntity> {
 
     private final EventBoundary eventBoundary;
 
@@ -15,24 +17,24 @@ public class RegistrationBoundary extends AbstractBoundary<
     }
 
     @Override
-    protected EntityMerger<org.coner.api.entity.Registration, Registration> buildApiToDomainMerger() {
+    protected EntityMerger<RegistrationApiEntity, Registration> buildApiToDomainMerger() {
         return new ReflectionEntityMerger<>();
     }
 
     @Override
-    protected EntityMerger<Registration, org.coner.api.entity.Registration> buildDomainToApiMerger() {
+    protected EntityMerger<Registration, RegistrationApiEntity> buildDomainToApiMerger() {
         return new ReflectionEntityMerger<>();
     }
 
     @Override
-    protected EntityMerger<Registration, org.coner.hibernate.entity.Registration> buildDomainToHibernateMerger() {
+    protected EntityMerger<Registration, RegistrationHibernateEntity> buildDomainToHibernateMerger() {
         return new ReflectionEntityMerger<>((sourceEntity, destinationEntity) -> {
             destinationEntity.setEvent(eventBoundary.toHibernateEntity(sourceEntity.getEvent()));
         });
     }
 
     @Override
-    protected EntityMerger<org.coner.hibernate.entity.Registration, Registration> buildHibernateToDomainMerger() {
+    protected EntityMerger<RegistrationHibernateEntity, Registration> buildHibernateToDomainMerger() {
         return new ReflectionEntityMerger<>((sourceEntity, destinationEntity) -> {
             destinationEntity.setEvent(eventBoundary.toDomainEntity(sourceEntity.getEvent()));
         });

--- a/dropwizard-app/src/main/java/org/coner/core/gateway/CompetitionGroupGateway.java
+++ b/dropwizard-app/src/main/java/org/coner/core/gateway/CompetitionGroupGateway.java
@@ -3,6 +3,7 @@ package org.coner.core.gateway;
 import org.coner.boundary.CompetitionGroupBoundary;
 import org.coner.core.domain.CompetitionGroup;
 import org.coner.hibernate.dao.CompetitionGroupDao;
+import org.coner.hibernate.entity.CompetitionGroupHibernateEntity;
 
 import com.google.common.base.*;
 import java.util.List;
@@ -22,23 +23,23 @@ public class CompetitionGroupGateway {
 
     public void create(CompetitionGroup competitionGroup) {
         Preconditions.checkNotNull(competitionGroup);
-        org.coner.hibernate.entity.CompetitionGroup hCompetitionGroup = competitionGroupBoundary.toHibernateEntity(
+        CompetitionGroupHibernateEntity competitionGroupHibernateEntity = competitionGroupBoundary.toHibernateEntity(
                 competitionGroup
         );
-        competitionGroupDao.createOrUpdate(hCompetitionGroup);
-        competitionGroupBoundary.merge(hCompetitionGroup, competitionGroup);
+        competitionGroupDao.createOrUpdate(competitionGroupHibernateEntity);
+        competitionGroupBoundary.merge(competitionGroupHibernateEntity, competitionGroup);
     }
 
     public List<CompetitionGroup> getAll() {
-        List<org.coner.hibernate.entity.CompetitionGroup> competitionGroups = competitionGroupDao.findAll();
-        return competitionGroupBoundary.toDomainEntities(competitionGroups);
+        List<CompetitionGroupHibernateEntity> competitionGroupHibernateEntities = competitionGroupDao.findAll();
+        return competitionGroupBoundary.toDomainEntities(competitionGroupHibernateEntities);
     }
 
     public CompetitionGroup findById(String competitionGroupId) {
         Preconditions.checkArgument(!Strings.isNullOrEmpty(competitionGroupId));
-        org.coner.hibernate.entity.CompetitionGroup hibernateCompetitionGroup = competitionGroupDao.findById(
+        CompetitionGroupHibernateEntity competitionGroupHibernateEntity = competitionGroupDao.findById(
                 competitionGroupId
         );
-        return competitionGroupBoundary.toDomainEntity(hibernateCompetitionGroup);
+        return competitionGroupBoundary.toDomainEntity(competitionGroupHibernateEntity);
     }
 }

--- a/dropwizard-app/src/main/java/org/coner/core/gateway/CompetitionGroupSetGateway.java
+++ b/dropwizard-app/src/main/java/org/coner/core/gateway/CompetitionGroupSetGateway.java
@@ -3,6 +3,7 @@ package org.coner.core.gateway;
 import org.coner.boundary.CompetitionGroupSetBoundary;
 import org.coner.core.domain.CompetitionGroupSet;
 import org.coner.hibernate.dao.CompetitionGroupSetDao;
+import org.coner.hibernate.entity.CompetitionGroupSetHibernateEntity;
 
 import com.google.common.base.Preconditions;
 
@@ -21,9 +22,9 @@ public class CompetitionGroupSetGateway {
 
     public void create(CompetitionGroupSet competitionGroupSet) {
         Preconditions.checkNotNull(competitionGroupSet);
-        org.coner.hibernate.entity.CompetitionGroupSet hCompetitionGroupSet = competitionGroupSetBoundary
+        CompetitionGroupSetHibernateEntity competitionGroupSetHibernateEntity = competitionGroupSetBoundary
                 .toHibernateEntity(competitionGroupSet);
-        competitionGroupSetDao.createOrUpdate(hCompetitionGroupSet);
-        competitionGroupSetBoundary.merge(hCompetitionGroupSet, competitionGroupSet);
+        competitionGroupSetDao.createOrUpdate(competitionGroupSetHibernateEntity);
+        competitionGroupSetBoundary.merge(competitionGroupSetHibernateEntity, competitionGroupSet);
     }
 }

--- a/dropwizard-app/src/main/java/org/coner/core/gateway/EventGateway.java
+++ b/dropwizard-app/src/main/java/org/coner/core/gateway/EventGateway.java
@@ -3,6 +3,7 @@ package org.coner.core.gateway;
 import org.coner.boundary.EventBoundary;
 import org.coner.core.domain.Event;
 import org.coner.hibernate.dao.EventDao;
+import org.coner.hibernate.entity.EventHibernateEntity;
 
 import com.google.common.base.*;
 import java.util.List;
@@ -18,19 +19,19 @@ public class EventGateway {
     }
 
     public List<Event> getAll() {
-        List<org.coner.hibernate.entity.Event> events = eventDao.findAll();
+        List<EventHibernateEntity> events = eventDao.findAll();
         return eventBoundary.toDomainEntities(events);
     }
 
     public Event findById(String eventId) {
         Preconditions.checkArgument(!Strings.isNullOrEmpty(eventId));
-        org.coner.hibernate.entity.Event hibernateEvent = eventDao.findById(eventId);
+        EventHibernateEntity hibernateEvent = eventDao.findById(eventId);
         return eventBoundary.toDomainEntity(hibernateEvent);
     }
 
     public void create(Event event) {
         Preconditions.checkNotNull(event);
-        org.coner.hibernate.entity.Event hibernateEvent = eventBoundary.toHibernateEntity(event);
+        EventHibernateEntity hibernateEvent = eventBoundary.toHibernateEntity(event);
         eventDao.create(hibernateEvent);
         eventBoundary.merge(hibernateEvent, event);
     }

--- a/dropwizard-app/src/main/java/org/coner/core/gateway/HandicapGroupGateway.java
+++ b/dropwizard-app/src/main/java/org/coner/core/gateway/HandicapGroupGateway.java
@@ -3,6 +3,7 @@ package org.coner.core.gateway;
 import org.coner.boundary.HandicapGroupBoundary;
 import org.coner.core.domain.HandicapGroup;
 import org.coner.hibernate.dao.HandicapGroupDao;
+import org.coner.hibernate.entity.HandicapGroupHibernateEntity;
 
 import com.google.common.base.*;
 import java.util.List;
@@ -19,20 +20,20 @@ public class HandicapGroupGateway {
 
     public void create(HandicapGroup handicapGroup) {
         Preconditions.checkNotNull(handicapGroup);
-        org.coner.hibernate.entity.HandicapGroup hibernateHandicapGroup =
+        HandicapGroupHibernateEntity hibernateHandicapGroup =
                 handicapGroupBoundary.toHibernateEntity(handicapGroup);
         handicapGroupDao.create(hibernateHandicapGroup);
         handicapGroupBoundary.merge(hibernateHandicapGroup, handicapGroup);
     }
 
     public List<HandicapGroup> getAll() {
-        List<org.coner.hibernate.entity.HandicapGroup> handicapGroups = handicapGroupDao.findAll();
+        List<HandicapGroupHibernateEntity> handicapGroups = handicapGroupDao.findAll();
         return handicapGroupBoundary.toDomainEntities(handicapGroups);
     }
 
     public HandicapGroup findById(String handicapGroupId) {
         Preconditions.checkArgument(!Strings.isNullOrEmpty(handicapGroupId));
-        org.coner.hibernate.entity.HandicapGroup hibernateHandicapGroup = handicapGroupDao.findById(handicapGroupId);
+        HandicapGroupHibernateEntity hibernateHandicapGroup = handicapGroupDao.findById(handicapGroupId);
         return handicapGroupBoundary.toDomainEntity(hibernateHandicapGroup);
     }
 }

--- a/dropwizard-app/src/main/java/org/coner/core/gateway/HandicapGroupSetGateway.java
+++ b/dropwizard-app/src/main/java/org/coner/core/gateway/HandicapGroupSetGateway.java
@@ -3,6 +3,7 @@ package org.coner.core.gateway;
 import org.coner.boundary.HandicapGroupSetBoundary;
 import org.coner.core.domain.HandicapGroupSet;
 import org.coner.hibernate.dao.HandicapGroupSetDao;
+import org.coner.hibernate.entity.HandicapGroupSetHibernateEntity;
 
 import com.google.common.base.Preconditions;
 
@@ -21,9 +22,9 @@ public class HandicapGroupSetGateway {
 
     public void create(HandicapGroupSet handicapGroupSet) {
         Preconditions.checkNotNull(handicapGroupSet);
-        org.coner.hibernate.entity.HandicapGroupSet hHandicapGroupSet = handicapGroupSetBoundary
+        HandicapGroupSetHibernateEntity handicapGroupSetHibernateEntity = handicapGroupSetBoundary
                 .toHibernateEntity(handicapGroupSet);
-        handicapGroupSetDao.createOrUpdate(hHandicapGroupSet);
-        handicapGroupSetBoundary.merge(hHandicapGroupSet, handicapGroupSet);
+        handicapGroupSetDao.createOrUpdate(handicapGroupSetHibernateEntity);
+        handicapGroupSetBoundary.merge(handicapGroupSetHibernateEntity, handicapGroupSet);
     }
 }

--- a/dropwizard-app/src/main/java/org/coner/core/gateway/RegistrationGateway.java
+++ b/dropwizard-app/src/main/java/org/coner/core/gateway/RegistrationGateway.java
@@ -3,6 +3,7 @@ package org.coner.core.gateway;
 import org.coner.boundary.*;
 import org.coner.core.domain.*;
 import org.coner.hibernate.dao.RegistrationDao;
+import org.coner.hibernate.entity.RegistrationHibernateEntity;
 
 import com.google.common.base.*;
 import java.util.List;
@@ -24,20 +25,20 @@ public class RegistrationGateway {
 
     public Registration findById(String registrationId) {
         Preconditions.checkArgument(!Strings.isNullOrEmpty(registrationId));
-        org.coner.hibernate.entity.Registration hibernateRegistration = registrationDao.findById(registrationId);
+        RegistrationHibernateEntity hibernateRegistration = registrationDao.findById(registrationId);
         return registrationBoundary.toDomainEntity(hibernateRegistration);
     }
 
     public List<Registration> getAllWith(Event event) {
         Preconditions.checkNotNull(event);
         org.coner.hibernate.entity.Event hibernateEvent = eventBoundary.toHibernateEntity(event);
-        List<org.coner.hibernate.entity.Registration> registrations = registrationDao.getAllWith(hibernateEvent);
+        List<RegistrationHibernateEntity> registrations = registrationDao.getAllWith(hibernateEvent);
         return registrationBoundary.toDomainEntities(registrations);
     }
 
     public void create(Registration registration) {
         Preconditions.checkNotNull(registration);
-        org.coner.hibernate.entity.Registration hibernateRegistration =
+        RegistrationHibernateEntity hibernateRegistration =
                 registrationBoundary.toHibernateEntity(registration);
         registrationDao.create(hibernateRegistration);
         registrationBoundary.merge(hibernateRegistration, registration);

--- a/dropwizard-app/src/main/java/org/coner/core/gateway/RegistrationGateway.java
+++ b/dropwizard-app/src/main/java/org/coner/core/gateway/RegistrationGateway.java
@@ -3,7 +3,7 @@ package org.coner.core.gateway;
 import org.coner.boundary.*;
 import org.coner.core.domain.*;
 import org.coner.hibernate.dao.RegistrationDao;
-import org.coner.hibernate.entity.RegistrationHibernateEntity;
+import org.coner.hibernate.entity.*;
 
 import com.google.common.base.*;
 import java.util.List;
@@ -31,7 +31,7 @@ public class RegistrationGateway {
 
     public List<Registration> getAllWith(Event event) {
         Preconditions.checkNotNull(event);
-        org.coner.hibernate.entity.Event hibernateEvent = eventBoundary.toHibernateEntity(event);
+        EventHibernateEntity hibernateEvent = eventBoundary.toHibernateEntity(event);
         List<RegistrationHibernateEntity> registrations = registrationDao.getAllWith(hibernateEvent);
         return registrationBoundary.toDomainEntities(registrations);
     }

--- a/dropwizard-app/src/main/java/org/coner/hibernate/dao/CompetitionGroupDao.java
+++ b/dropwizard-app/src/main/java/org/coner/hibernate/dao/CompetitionGroupDao.java
@@ -1,26 +1,26 @@
 package org.coner.hibernate.dao;
 
-import org.coner.hibernate.entity.CompetitionGroup;
+import org.coner.hibernate.entity.CompetitionGroupHibernateEntity;
 
 import io.dropwizard.hibernate.AbstractDAO;
 import java.util.List;
 import org.hibernate.SessionFactory;
 
-public class CompetitionGroupDao extends AbstractDAO<CompetitionGroup> {
+public class CompetitionGroupDao extends AbstractDAO<CompetitionGroupHibernateEntity> {
 
     public CompetitionGroupDao(SessionFactory sessionFactory) {
         super(sessionFactory);
     }
 
-    public void createOrUpdate(CompetitionGroup competitionGroup) {
+    public void createOrUpdate(CompetitionGroupHibernateEntity competitionGroup) {
         persist(competitionGroup);
     }
 
-    public List<CompetitionGroup> findAll() {
-        return list(namedQuery(CompetitionGroup.QUERY_FIND_ALL));
+    public List<CompetitionGroupHibernateEntity> findAll() {
+        return list(namedQuery(CompetitionGroupHibernateEntity.QUERY_FIND_ALL));
     }
 
-    public CompetitionGroup findById(String id) {
+    public CompetitionGroupHibernateEntity findById(String id) {
         return get(id);
     }
 }

--- a/dropwizard-app/src/main/java/org/coner/hibernate/dao/CompetitionGroupSetDao.java
+++ b/dropwizard-app/src/main/java/org/coner/hibernate/dao/CompetitionGroupSetDao.java
@@ -1,17 +1,17 @@
 package org.coner.hibernate.dao;
 
-import org.coner.hibernate.entity.CompetitionGroupSet;
+import org.coner.hibernate.entity.CompetitionGroupSetHibernateEntity;
 
 import io.dropwizard.hibernate.AbstractDAO;
 import org.hibernate.SessionFactory;
 
-public class CompetitionGroupSetDao extends AbstractDAO<CompetitionGroupSet> {
+public class CompetitionGroupSetDao extends AbstractDAO<CompetitionGroupSetHibernateEntity> {
 
     public CompetitionGroupSetDao(SessionFactory sessionFactory) {
         super(sessionFactory);
     }
 
-    public void createOrUpdate(CompetitionGroupSet competitionGroupSet) {
+    public void createOrUpdate(CompetitionGroupSetHibernateEntity competitionGroupSet) {
         persist(competitionGroupSet);
     }
 }

--- a/dropwizard-app/src/main/java/org/coner/hibernate/dao/EventDao.java
+++ b/dropwizard-app/src/main/java/org/coner/hibernate/dao/EventDao.java
@@ -1,27 +1,27 @@
 package org.coner.hibernate.dao;
 
-import org.coner.hibernate.entity.Event;
+import org.coner.hibernate.entity.EventHibernateEntity;
 
 import io.dropwizard.hibernate.AbstractDAO;
 import java.util.List;
 import org.hibernate.SessionFactory;
 
-public class EventDao extends AbstractDAO<Event> {
+public class EventDao extends AbstractDAO<EventHibernateEntity> {
 
 
     public EventDao(SessionFactory sessionFactory) {
         super(sessionFactory);
     }
 
-    public Event findById(String id) {
+    public EventHibernateEntity findById(String id) {
         return get(id);
     }
 
-    public List<Event> findAll() {
-        return list(namedQuery(Event.QUERY_FIND_ALL));
+    public List<EventHibernateEntity> findAll() {
+        return list(namedQuery(EventHibernateEntity.QUERY_FIND_ALL));
     }
 
-    public void create(Event event) {
+    public void create(EventHibernateEntity event) {
         persist(event);
     }
 }

--- a/dropwizard-app/src/main/java/org/coner/hibernate/dao/HandicapGroupDao.java
+++ b/dropwizard-app/src/main/java/org/coner/hibernate/dao/HandicapGroupDao.java
@@ -1,26 +1,26 @@
 package org.coner.hibernate.dao;
 
-import org.coner.hibernate.entity.HandicapGroup;
+import org.coner.hibernate.entity.HandicapGroupHibernateEntity;
 
 import io.dropwizard.hibernate.AbstractDAO;
 import java.util.List;
 import org.hibernate.SessionFactory;
 
-public class HandicapGroupDao extends AbstractDAO<HandicapGroup> {
+public class HandicapGroupDao extends AbstractDAO<HandicapGroupHibernateEntity> {
 
     public HandicapGroupDao(SessionFactory sessionFactory) {
         super(sessionFactory);
     }
 
-    public void create(HandicapGroup handicapGroup) {
+    public void create(HandicapGroupHibernateEntity handicapGroup) {
         persist(handicapGroup);
     }
 
-    public List<HandicapGroup> findAll() {
-        return list(namedQuery(HandicapGroup.QUERY_FIND_ALL));
+    public List<HandicapGroupHibernateEntity> findAll() {
+        return list(namedQuery(HandicapGroupHibernateEntity.QUERY_FIND_ALL));
     }
 
-    public HandicapGroup findById(String id) {
+    public HandicapGroupHibernateEntity findById(String id) {
         return get(id);
     }
 }

--- a/dropwizard-app/src/main/java/org/coner/hibernate/dao/HandicapGroupSetDao.java
+++ b/dropwizard-app/src/main/java/org/coner/hibernate/dao/HandicapGroupSetDao.java
@@ -1,17 +1,17 @@
 package org.coner.hibernate.dao;
 
-import org.coner.hibernate.entity.HandicapGroupSet;
+import org.coner.hibernate.entity.HandicapGroupSetHibernateEntity;
 
 import io.dropwizard.hibernate.AbstractDAO;
 import org.hibernate.SessionFactory;
 
-public class HandicapGroupSetDao extends AbstractDAO<HandicapGroupSet> {
+public class HandicapGroupSetDao extends AbstractDAO<HandicapGroupSetHibernateEntity> {
 
     public HandicapGroupSetDao(SessionFactory sessionFactory) {
         super(sessionFactory);
     }
 
-    public void createOrUpdate(HandicapGroupSet handicapGroupSet) {
+    public void createOrUpdate(HandicapGroupSetHibernateEntity handicapGroupSet) {
         persist(handicapGroupSet);
     }
 }

--- a/dropwizard-app/src/main/java/org/coner/hibernate/dao/RegistrationDao.java
+++ b/dropwizard-app/src/main/java/org/coner/hibernate/dao/RegistrationDao.java
@@ -16,7 +16,7 @@ public class RegistrationDao extends AbstractDAO<RegistrationHibernateEntity> {
         return get(id);
     }
 
-    public List<RegistrationHibernateEntity> getAllWith(Event event) {
+    public List<RegistrationHibernateEntity> getAllWith(EventHibernateEntity event) {
         Query query = namedQuery(RegistrationHibernateEntity.QUERY_FIND_ALL_WITH_EVENT);
         query.setParameter(RegistrationHibernateEntity.PARAMETER_EVENT_ID, event.getId());
         return list(query);

--- a/dropwizard-app/src/main/java/org/coner/hibernate/dao/RegistrationDao.java
+++ b/dropwizard-app/src/main/java/org/coner/hibernate/dao/RegistrationDao.java
@@ -6,23 +6,23 @@ import io.dropwizard.hibernate.AbstractDAO;
 import java.util.List;
 import org.hibernate.*;
 
-public class RegistrationDao extends AbstractDAO<Registration> {
+public class RegistrationDao extends AbstractDAO<RegistrationHibernateEntity> {
 
     public RegistrationDao(SessionFactory sessionFactory) {
         super(sessionFactory);
     }
 
-    public Registration findById(String id) {
+    public RegistrationHibernateEntity findById(String id) {
         return get(id);
     }
 
-    public List<Registration> getAllWith(Event event) {
-        Query query = namedQuery(Registration.QUERY_FIND_ALL_WITH_EVENT);
-        query.setParameter(Registration.PARAMETER_EVENT_ID, event.getId());
+    public List<RegistrationHibernateEntity> getAllWith(Event event) {
+        Query query = namedQuery(RegistrationHibernateEntity.QUERY_FIND_ALL_WITH_EVENT);
+        query.setParameter(RegistrationHibernateEntity.PARAMETER_EVENT_ID, event.getId());
         return list(query);
     }
 
-    public void create(Registration registration) {
+    public void create(RegistrationHibernateEntity registration) {
         persist(registration);
     }
 }

--- a/dropwizard-app/src/main/java/org/coner/hibernate/entity/CompetitionGroupHibernateEntity.java
+++ b/dropwizard-app/src/main/java/org/coner/hibernate/entity/CompetitionGroupHibernateEntity.java
@@ -9,13 +9,13 @@ import org.hibernate.annotations.GenericGenerator;
 @Table(name = "competition_groups")
 @NamedQueries({
         @NamedQuery(
-                name = CompetitionGroup.QUERY_FIND_ALL,
-                query = "from CompetitionGroup"
+                name = CompetitionGroupHibernateEntity.QUERY_FIND_ALL,
+                query = "from CompetitionGroupHibernateEntity"
         )
 })
-public class CompetitionGroup extends HibernateEntity {
+public class CompetitionGroupHibernateEntity extends HibernateEntity {
 
-    public static final String QUERY_FIND_ALL = "org.coner.hibernate.entity.CompetitionGroup.findAll";
+    public static final String QUERY_FIND_ALL = "org.coner.hibernate.entity.CompetitionGroupHibernateEntity.findAll";
 
     private String id;
     private String name;

--- a/dropwizard-app/src/main/java/org/coner/hibernate/entity/CompetitionGroupHibernateEntity.java
+++ b/dropwizard-app/src/main/java/org/coner/hibernate/entity/CompetitionGroupHibernateEntity.java
@@ -22,7 +22,7 @@ public class CompetitionGroupHibernateEntity extends HibernateEntity {
     private BigDecimal handicapFactor;
     private boolean grouping;
     private String resultTimeType;
-    private Set<CompetitionGroupSet> competitionGroupSets;
+    private Set<CompetitionGroupSetHibernateEntity> competitionGroupSets;
 
     @Id
     @Column(name = "competitionGroupId", unique = true, nullable = false)
@@ -82,11 +82,11 @@ public class CompetitionGroupHibernateEntity extends HibernateEntity {
                     @JoinColumn(name = "competitionGroupSetId", nullable = false, updatable = false)
             }
     )
-    public Set<CompetitionGroupSet> getCompetitionGroupSets() {
+    public Set<CompetitionGroupSetHibernateEntity> getCompetitionGroupSets() {
         return this.competitionGroupSets;
     }
 
-    public void setCompetitionGroupSets(Set<CompetitionGroupSet> competitionGroupSets) {
+    public void setCompetitionGroupSets(Set<CompetitionGroupSetHibernateEntity> competitionGroupSets) {
         this.competitionGroupSets = competitionGroupSets;
     }
 }

--- a/dropwizard-app/src/main/java/org/coner/hibernate/entity/CompetitionGroupSet.java
+++ b/dropwizard-app/src/main/java/org/coner/hibernate/entity/CompetitionGroupSet.java
@@ -10,7 +10,7 @@ public class CompetitionGroupSet extends HibernateEntity {
 
     private String competitionGroupSetId;
     private String name;
-    private Set<CompetitionGroup> competitionGroups;
+    private Set<CompetitionGroupHibernateEntity> competitionGroups;
 
     @Id
     @Column(name = "competitionGroupSetId")
@@ -34,11 +34,11 @@ public class CompetitionGroupSet extends HibernateEntity {
     }
 
     @ManyToMany(fetch = FetchType.EAGER, mappedBy = "competitionGroupSets")
-    public Set<CompetitionGroup> getCompetitionGroups() {
+    public Set<CompetitionGroupHibernateEntity> getCompetitionGroups() {
         return competitionGroups;
     }
 
-    public void setCompetitionGroups(Set<CompetitionGroup> competitionGroups) {
+    public void setCompetitionGroups(Set<CompetitionGroupHibernateEntity> competitionGroups) {
         this.competitionGroups = competitionGroups;
     }
 }

--- a/dropwizard-app/src/main/java/org/coner/hibernate/entity/CompetitionGroupSetHibernateEntity.java
+++ b/dropwizard-app/src/main/java/org/coner/hibernate/entity/CompetitionGroupSetHibernateEntity.java
@@ -6,7 +6,7 @@ import org.hibernate.annotations.GenericGenerator;
 
 @Entity
 @Table(name = "competition_group_sets")
-public class CompetitionGroupSet extends HibernateEntity {
+public class CompetitionGroupSetHibernateEntity extends HibernateEntity {
 
     private String competitionGroupSetId;
     private String name;

--- a/dropwizard-app/src/main/java/org/coner/hibernate/entity/EventHibernateEntity.java
+++ b/dropwizard-app/src/main/java/org/coner/hibernate/entity/EventHibernateEntity.java
@@ -1,20 +1,27 @@
-package org.coner.api.entity;
+package org.coner.hibernate.entity;
 
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.util.Date;
-import javax.validation.constraints.*;
-import org.hibernate.validator.constraints.NotBlank;
+import javax.persistence.*;
+import org.hibernate.annotations.GenericGenerator;
 
-@JsonPropertyOrder({"id", "name", "date"})
-public class Event extends ApiEntity {
+@Entity
+@Table(name = "events")
+@NamedQueries({
+        @NamedQuery(
+                name = EventHibernateEntity.QUERY_FIND_ALL,
+                query = "from EventHibernateEntity"
+        )
+})
+public class EventHibernateEntity extends HibernateEntity {
 
-    @Null(message = "event.id may only be assigned by the system")
+    public static final String QUERY_FIND_ALL = "org.coner.hibernate.entity.EventHibernateEntity.findAll";
     private String id;
-    @NotBlank
     private String name;
-    @NotNull
     private Date date;
 
+    @Id
+    @GeneratedValue(generator = "uuid")
+    @GenericGenerator(name = "uuid", strategy = "uuid2")
     public String getId() {
         return id;
     }
@@ -23,6 +30,7 @@ public class Event extends ApiEntity {
         this.id = id;
     }
 
+    @Column(name = "name")
     public String getName() {
         return name;
     }
@@ -31,6 +39,8 @@ public class Event extends ApiEntity {
         this.name = name;
     }
 
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name = "date")
     public Date getDate() {
         return date;
     }
@@ -44,9 +54,9 @@ public class Event extends ApiEntity {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
 
-        Event event = (Event) o;
+        EventHibernateEntity event = (EventHibernateEntity) o;
 
-        if (date != null ? !date.equals(event.date) : event.date != null) return false;
+        if (date != null ? !(date.compareTo(event.date) == 0) : event.date != null) return false;
         if (id != null ? !id.equals(event.id) : event.id != null) return false;
         if (name != null ? !name.equals(event.name) : event.name != null) return false;
 

--- a/dropwizard-app/src/main/java/org/coner/hibernate/entity/HandicapGroupHibernateEntity.java
+++ b/dropwizard-app/src/main/java/org/coner/hibernate/entity/HandicapGroupHibernateEntity.java
@@ -9,12 +9,12 @@ import org.hibernate.annotations.GenericGenerator;
 @Table(name = "handicap_groups")
 @NamedQueries({
         @NamedQuery(
-                name = HandicapGroup.QUERY_FIND_ALL,
-                query = "from HandicapGroup"
+                name = HandicapGroupHibernateEntity.QUERY_FIND_ALL,
+                query = "from HandicapGroupHibernateEntity"
         )
 })
-public class HandicapGroup extends HibernateEntity {
-    public static final String QUERY_FIND_ALL = "org.coner.hibernate.entity.HandicapGroup.findAll";
+public class HandicapGroupHibernateEntity extends HibernateEntity {
+    public static final String QUERY_FIND_ALL = "org.coner.hibernate.entity.HandicapGroupHibernateEntity.findAll";
 
     private String id;
     private String name;

--- a/dropwizard-app/src/main/java/org/coner/hibernate/entity/HandicapGroupHibernateEntity.java
+++ b/dropwizard-app/src/main/java/org/coner/hibernate/entity/HandicapGroupHibernateEntity.java
@@ -19,7 +19,7 @@ public class HandicapGroupHibernateEntity extends HibernateEntity {
     private String id;
     private String name;
     private BigDecimal handicapFactor;
-    private Set<HandicapGroupSet> handicapGroupSets;
+    private Set<HandicapGroupSetHibernateEntity> handicapGroupSets;
 
     @Id
     @GeneratedValue(generator = "uuid")
@@ -60,11 +60,11 @@ public class HandicapGroupHibernateEntity extends HibernateEntity {
                     @JoinColumn(name = "handicapGroupSetId", nullable = false, updatable = false)
             }
     )
-    public Set<HandicapGroupSet> getHandicapGroupSets() {
+    public Set<HandicapGroupSetHibernateEntity> getHandicapGroupSets() {
         return handicapGroupSets;
     }
 
-    public void setHandicapGroupSets(Set<HandicapGroupSet> handicapGroupSets) {
+    public void setHandicapGroupSets(Set<HandicapGroupSetHibernateEntity> handicapGroupSets) {
         this.handicapGroupSets = handicapGroupSets;
     }
 }

--- a/dropwizard-app/src/main/java/org/coner/hibernate/entity/HandicapGroupSet.java
+++ b/dropwizard-app/src/main/java/org/coner/hibernate/entity/HandicapGroupSet.java
@@ -10,7 +10,7 @@ public class HandicapGroupSet extends HibernateEntity {
 
     private String handicapGroupSetId;
     private String name;
-    private Set<HandicapGroup> handicapGroups;
+    private Set<HandicapGroupHibernateEntity> handicapGroups;
 
     @Id
     @Column(name = "handicapGroupSetId")
@@ -34,11 +34,11 @@ public class HandicapGroupSet extends HibernateEntity {
     }
 
     @ManyToMany(fetch = FetchType.EAGER, mappedBy = "handicapGroupSets")
-    public Set<HandicapGroup> getHandicapGroups() {
+    public Set<HandicapGroupHibernateEntity> getHandicapGroups() {
         return handicapGroups;
     }
 
-    public void setHandicapGroups(Set<HandicapGroup> handicapGroups) {
+    public void setHandicapGroups(Set<HandicapGroupHibernateEntity> handicapGroups) {
         this.handicapGroups = handicapGroups;
     }
 }

--- a/dropwizard-app/src/main/java/org/coner/hibernate/entity/HandicapGroupSetHibernateEntity.java
+++ b/dropwizard-app/src/main/java/org/coner/hibernate/entity/HandicapGroupSetHibernateEntity.java
@@ -6,7 +6,7 @@ import org.hibernate.annotations.GenericGenerator;
 
 @Entity
 @Table(name = "handicap_group_sets")
-public class HandicapGroupSet extends HibernateEntity {
+public class HandicapGroupSetHibernateEntity extends HibernateEntity {
 
     private String handicapGroupSetId;
     private String name;

--- a/dropwizard-app/src/main/java/org/coner/hibernate/entity/RegistrationHibernateEntity.java
+++ b/dropwizard-app/src/main/java/org/coner/hibernate/entity/RegistrationHibernateEntity.java
@@ -7,13 +7,15 @@ import org.hibernate.annotations.GenericGenerator;
 @Table(name = "registrations")
 @NamedQueries({
         @NamedQuery(
-                name = Registration.QUERY_FIND_ALL_WITH_EVENT,
-                query = "FROM Registration r WHERE r.event.id = :" + Registration.PARAMETER_EVENT_ID
+                name = RegistrationHibernateEntity.QUERY_FIND_ALL_WITH_EVENT,
+                query = "FROM RegistrationHibernateEntity r "
+                        + "WHERE r.event.id = :" + RegistrationHibernateEntity.PARAMETER_EVENT_ID
         )
 })
-public class Registration extends HibernateEntity {
+public class RegistrationHibernateEntity extends HibernateEntity {
 
-    public static final String QUERY_FIND_ALL_WITH_EVENT = "org.coner.hibernate.entity.Registration.findAllWithEvent";
+    public static final String QUERY_FIND_ALL_WITH_EVENT = "org.coner.hibernate.entity.RegistrationHibernateEntity"
+            + ".findAllWithEvent";
     public static final String PARAMETER_EVENT_ID = "eventId";
 
     private String id;

--- a/dropwizard-app/src/main/java/org/coner/hibernate/entity/RegistrationHibernateEntity.java
+++ b/dropwizard-app/src/main/java/org/coner/hibernate/entity/RegistrationHibernateEntity.java
@@ -21,7 +21,7 @@ public class RegistrationHibernateEntity extends HibernateEntity {
     private String id;
     private String firstName;
     private String lastName;
-    private Event event;
+    private EventHibernateEntity event;
 
     @Id
     @GeneratedValue(generator = "uuid")
@@ -53,11 +53,11 @@ public class RegistrationHibernateEntity extends HibernateEntity {
     }
 
     @ManyToOne
-    public Event getEvent() {
+    public EventHibernateEntity getEvent() {
         return event;
     }
 
-    public void setEvent(Event event) {
+    public void setEvent(EventHibernateEntity event) {
         this.event = event;
     }
 }

--- a/dropwizard-app/src/main/java/org/coner/resource/CompetitionGroupResource.java
+++ b/dropwizard-app/src/main/java/org/coner/resource/CompetitionGroupResource.java
@@ -1,6 +1,6 @@
 package org.coner.resource;
 
-import org.coner.api.entity.CompetitionGroup;
+import org.coner.api.entity.CompetitionGroupApiEntity;
 import org.coner.api.response.ErrorsResponse;
 import org.coner.boundary.CompetitionGroupBoundary;
 import org.coner.core.ConerCoreService;
@@ -30,19 +30,18 @@ public class CompetitionGroupResource {
 
     @GET
     @UnitOfWork
-    @ApiOperation(value = "Get a Competition Group", response = CompetitionGroup.class)
+    @ApiOperation(value = "Get a Competition Group", response = CompetitionGroupApiEntity.class)
     @ApiResponses({
-            @ApiResponse(code = HttpStatus.OK_200, response = CompetitionGroup.class, message = "OK"),
+            @ApiResponse(code = HttpStatus.OK_200, response = CompetitionGroupApiEntity.class, message = "OK"),
             @ApiResponse(code = HttpStatus.NOT_FOUND_404, response = ErrorsResponse.class, message = "Not found")
     })
-    public CompetitionGroup getCompetitionGroup(
+    public CompetitionGroupApiEntity getCompetitionGroup(
             @PathParam("competitionGroupId") @ApiParam(value = "Competition Group ID", required = true) String id
     ) {
         org.coner.core.domain.CompetitionGroup domainCompetitionGroup = conerCoreService.getCompetitionGroup(id);
         if (domainCompetitionGroup == null) {
             throw new NotFoundException("No competition group with id " + id);
         }
-        CompetitionGroup competitionGroup = competitionGroupBoundary.toApiEntity(domainCompetitionGroup);
-        return competitionGroup;
+        return competitionGroupBoundary.toApiEntity(domainCompetitionGroup);
     }
 }

--- a/dropwizard-app/src/main/java/org/coner/resource/CompetitionGroupResource.java
+++ b/dropwizard-app/src/main/java/org/coner/resource/CompetitionGroupResource.java
@@ -4,6 +4,7 @@ import org.coner.api.entity.CompetitionGroupApiEntity;
 import org.coner.api.response.ErrorsResponse;
 import org.coner.boundary.CompetitionGroupBoundary;
 import org.coner.core.ConerCoreService;
+import org.coner.core.domain.CompetitionGroup;
 
 import com.wordnik.swagger.annotations.*;
 import io.dropwizard.hibernate.UnitOfWork;
@@ -38,7 +39,7 @@ public class CompetitionGroupResource {
     public CompetitionGroupApiEntity getCompetitionGroup(
             @PathParam("competitionGroupId") @ApiParam(value = "Competition Group ID", required = true) String id
     ) {
-        org.coner.core.domain.CompetitionGroup domainCompetitionGroup = conerCoreService.getCompetitionGroup(id);
+        CompetitionGroup domainCompetitionGroup = conerCoreService.getCompetitionGroup(id);
         if (domainCompetitionGroup == null) {
             throw new NotFoundException("No competition group with id " + id);
         }

--- a/dropwizard-app/src/main/java/org/coner/resource/CompetitionGroupSetsResource.java
+++ b/dropwizard-app/src/main/java/org/coner/resource/CompetitionGroupSetsResource.java
@@ -57,15 +57,15 @@ public class CompetitionGroupSetsResource {
     ) {
         org.coner.core.domain.CompetitionGroupSet domainCompetitionGroupSet = competitionGroupSetBoundary
                 .toDomainEntity(request);
-        Set<AddCompetitionGroupSetRequest.CompetitionGroup> rxApiCompetitionGroups = request.getCompetitionGroups();
-        if (rxApiCompetitionGroups != null) {
-            Set<org.coner.core.domain.CompetitionGroup> domainCompetitionGroups = new HashSet<>();
-            for (AddCompetitionGroupSetRequest.CompetitionGroup rxCompetitionGroup : rxApiCompetitionGroups) {
+        Set<AddCompetitionGroupSetRequest.CompetitionGroup> requestCompetitionGroups = request.getCompetitionGroups();
+        if (requestCompetitionGroups != null) {
+            Set<CompetitionGroup> domainCompetitionGroups = new HashSet<>();
+            for (AddCompetitionGroupSetRequest.CompetitionGroup requestCompetitionGroup : requestCompetitionGroups) {
                 CompetitionGroup domainCompetitionGroup = conerCoreService.getCompetitionGroup(
-                        rxCompetitionGroup.getId()
+                        requestCompetitionGroup.getId()
                 );
                 if (domainCompetitionGroup == null) {
-                    throw new NotFoundException("No competition group with id " + rxCompetitionGroup.getId());
+                    throw new NotFoundException("No competition group with id " + requestCompetitionGroup.getId());
                 }
                 domainCompetitionGroups.add(domainCompetitionGroup);
             }

--- a/dropwizard-app/src/main/java/org/coner/resource/CompetitionGroupsResource.java
+++ b/dropwizard-app/src/main/java/org/coner/resource/CompetitionGroupsResource.java
@@ -1,6 +1,6 @@
 package org.coner.resource;
 
-import org.coner.api.entity.CompetitionGroup;
+import org.coner.api.entity.CompetitionGroupApiEntity;
 import org.coner.api.response.*;
 import org.coner.boundary.CompetitionGroupBoundary;
 import org.coner.core.ConerCoreService;
@@ -45,10 +45,10 @@ public class CompetitionGroupsResource {
             )
     })
     public Response addCompetitionGroup(
-            @Valid @ApiParam(value = "Competition Group") CompetitionGroup competitionGroup
+            @Valid @ApiParam(value = "Competition Group") CompetitionGroupApiEntity competitionGroupApiEntity
     ) {
         org.coner.core.domain.CompetitionGroup domainCompetitionGroup = competitionGroupBoundary.toDomainEntity(
-                competitionGroup
+                competitionGroupApiEntity
         );
         conerCoreService.addCompetitionGroup(domainCompetitionGroup);
         return Response.created(UriBuilder.fromResource(CompetitionGroupResource.class)

--- a/dropwizard-app/src/main/java/org/coner/resource/CompetitionGroupsResource.java
+++ b/dropwizard-app/src/main/java/org/coner/resource/CompetitionGroupsResource.java
@@ -4,6 +4,7 @@ import org.coner.api.entity.CompetitionGroupApiEntity;
 import org.coner.api.response.*;
 import org.coner.boundary.CompetitionGroupBoundary;
 import org.coner.core.ConerCoreService;
+import org.coner.core.domain.CompetitionGroup;
 
 import com.wordnik.swagger.annotations.*;
 import io.dropwizard.hibernate.UnitOfWork;
@@ -47,9 +48,7 @@ public class CompetitionGroupsResource {
     public Response addCompetitionGroup(
             @Valid @ApiParam(value = "Competition Group") CompetitionGroupApiEntity competitionGroupApiEntity
     ) {
-        org.coner.core.domain.CompetitionGroup domainCompetitionGroup = competitionGroupBoundary.toDomainEntity(
-                competitionGroupApiEntity
-        );
+        CompetitionGroup domainCompetitionGroup = competitionGroupBoundary.toDomainEntity(competitionGroupApiEntity);
         conerCoreService.addCompetitionGroup(domainCompetitionGroup);
         return Response.created(UriBuilder.fromResource(CompetitionGroupResource.class)
                 .build(domainCompetitionGroup.getId()))
@@ -60,7 +59,7 @@ public class CompetitionGroupsResource {
     @UnitOfWork
     @ApiOperation(value = "Get all Competition Groups", response = GetCompetitionGroupsResponse.class)
     public GetCompetitionGroupsResponse getCompetitionGroups() {
-        List<org.coner.core.domain.CompetitionGroup> domainCompetitionGroups = conerCoreService.getCompetitionGroups();
+        List<CompetitionGroup> domainCompetitionGroups = conerCoreService.getCompetitionGroups();
         GetCompetitionGroupsResponse response = new GetCompetitionGroupsResponse();
         response.setCompetitionGroups(competitionGroupBoundary.toApiEntities(domainCompetitionGroups));
         return response;

--- a/dropwizard-app/src/main/java/org/coner/resource/EventRegistrationResource.java
+++ b/dropwizard-app/src/main/java/org/coner/resource/EventRegistrationResource.java
@@ -1,9 +1,10 @@
 package org.coner.resource;
 
-import org.coner.api.entity.Registration;
+import org.coner.api.entity.RegistrationApiEntity;
 import org.coner.api.response.ErrorsResponse;
 import org.coner.boundary.*;
 import org.coner.core.ConerCoreService;
+import org.coner.core.domain.Registration;
 import org.coner.core.exception.EventRegistrationMismatchException;
 
 import com.wordnik.swagger.annotations.*;
@@ -36,7 +37,7 @@ public class EventRegistrationResource {
     @UnitOfWork
     @ApiOperation(value = "Get a specific registration")
     @ApiResponses({
-            @ApiResponse(code = HttpStatus.OK_200, response = Registration.class, message = "OK"),
+            @ApiResponse(code = HttpStatus.OK_200, response = RegistrationApiEntity.class, message = "OK"),
             @ApiResponse(code = HttpStatus.NOT_FOUND_404, response = ErrorsResponse.class, message = "Not found"),
             @ApiResponse(
                     code = HttpStatus.CONFLICT_409,
@@ -48,12 +49,9 @@ public class EventRegistrationResource {
             @PathParam("eventId") @ApiParam(value = "Event ID", required = true) String eventId,
             @PathParam("registrationId") @ApiParam(value = "Registration ID", required = true) String registrationId
     ) {
-        org.coner.core.domain.Registration domainRegistration;
+        Registration domainRegistration;
         try {
-            domainRegistration = conerCoreService.getRegistration(
-                    eventId,
-                    registrationId
-            );
+            domainRegistration = conerCoreService.getRegistration(eventId, registrationId);
         } catch (EventRegistrationMismatchException e) {
             ErrorsResponse errorsResponse = new ErrorsResponse();
             errorsResponse.setErrors(Arrays.asList(
@@ -69,7 +67,7 @@ public class EventRegistrationResource {
             throw new NotFoundException("No registration with id " + registrationId);
         }
 
-        Registration registration = registrationBoundary.toApiEntity(domainRegistration);
+        RegistrationApiEntity registration = registrationBoundary.toApiEntity(domainRegistration);
 
         return Response.ok(registration, MediaType.APPLICATION_JSON_TYPE)
                 .build();

--- a/dropwizard-app/src/main/java/org/coner/resource/EventRegistrationsResource.java
+++ b/dropwizard-app/src/main/java/org/coner/resource/EventRegistrationsResource.java
@@ -4,7 +4,7 @@ import org.coner.api.entity.RegistrationApiEntity;
 import org.coner.api.response.*;
 import org.coner.boundary.*;
 import org.coner.core.ConerCoreService;
-import org.coner.core.domain.Registration;
+import org.coner.core.domain.*;
 
 import com.wordnik.swagger.annotations.*;
 import io.dropwizard.hibernate.UnitOfWork;
@@ -54,7 +54,7 @@ public class EventRegistrationsResource {
     public GetEventRegistrationsResponse getEventRegistrations(
             @PathParam("eventId") @ApiParam(value = "Event ID", required = true) String eventId
     ) {
-        org.coner.core.domain.Event domainEvent = conerCoreService.getEvent(eventId);
+        Event domainEvent = conerCoreService.getEvent(eventId);
         if (domainEvent == null) {
             throw new NotFoundException("No event with id " + eventId);
         }
@@ -91,7 +91,7 @@ public class EventRegistrationsResource {
             @Valid @ApiParam(value = "Registration", required = true) RegistrationApiEntity registration
     ) {
         Registration domainRegistration = registrationBoundary.toDomainEntity(registration);
-        org.coner.core.domain.Event domainEvent = conerCoreService.getEvent(eventId);
+        Event domainEvent = conerCoreService.getEvent(eventId);
         if (domainEvent == null) {
             throw new NotFoundException("No event with id " + eventId);
         }

--- a/dropwizard-app/src/main/java/org/coner/resource/EventRegistrationsResource.java
+++ b/dropwizard-app/src/main/java/org/coner/resource/EventRegistrationsResource.java
@@ -1,9 +1,10 @@
 package org.coner.resource;
 
-import org.coner.api.entity.Registration;
+import org.coner.api.entity.RegistrationApiEntity;
 import org.coner.api.response.*;
 import org.coner.boundary.*;
 import org.coner.core.ConerCoreService;
+import org.coner.core.domain.Registration;
 
 import com.wordnik.swagger.annotations.*;
 import io.dropwizard.hibernate.UnitOfWork;
@@ -57,7 +58,7 @@ public class EventRegistrationsResource {
         if (domainEvent == null) {
             throw new NotFoundException("No event with id " + eventId);
         }
-        List<Registration> registrations = registrationBoundary.toApiEntities(
+        List<RegistrationApiEntity> registrations = registrationBoundary.toApiEntities(
                 conerCoreService.getRegistrations(domainEvent)
         );
         GetEventRegistrationsResponse response = new GetEventRegistrationsResponse();
@@ -87,9 +88,9 @@ public class EventRegistrationsResource {
     })
     public Response addRegistration(
             @PathParam("eventId") @ApiParam(value = "Event ID", required = true) String eventId,
-            @Valid @ApiParam(value = "Registration", required = true) Registration registration
+            @Valid @ApiParam(value = "Registration", required = true) RegistrationApiEntity registration
     ) {
-        org.coner.core.domain.Registration domainRegistration = registrationBoundary.toDomainEntity(registration);
+        Registration domainRegistration = registrationBoundary.toDomainEntity(registration);
         org.coner.core.domain.Event domainEvent = conerCoreService.getEvent(eventId);
         if (domainEvent == null) {
             throw new NotFoundException("No event with id " + eventId);

--- a/dropwizard-app/src/main/java/org/coner/resource/EventResource.java
+++ b/dropwizard-app/src/main/java/org/coner/resource/EventResource.java
@@ -1,9 +1,10 @@
 package org.coner.resource;
 
-import org.coner.api.entity.Event;
+import org.coner.api.entity.EventApiEntity;
 import org.coner.api.response.ErrorsResponse;
 import org.coner.boundary.EventBoundary;
 import org.coner.core.ConerCoreService;
+import org.coner.core.domain.Event;
 
 import com.wordnik.swagger.annotations.*;
 import io.dropwizard.hibernate.UnitOfWork;
@@ -29,17 +30,17 @@ public class EventResource {
     @UnitOfWork
     @ApiOperation(value = "Get an Event")
     @ApiResponses({
-            @ApiResponse(code = HttpStatus.OK_200, response = Event.class, message = "OK"),
+            @ApiResponse(code = HttpStatus.OK_200, response = EventApiEntity.class, message = "OK"),
             @ApiResponse(code = HttpStatus.NOT_FOUND_404, response = ErrorsResponse.class, message = "Not found")
     })
-    public Event getEvent(
+    public EventApiEntity getEvent(
             @PathParam("eventId") @ApiParam(value = "Event ID", required = true) String id
     ) {
-        org.coner.core.domain.Event domainEvent = conerCoreService.getEvent(id);
+        Event domainEvent = conerCoreService.getEvent(id);
         if (domainEvent == null) {
             throw new NotFoundException("No event found with id " + id);
         }
-        Event event = eventBoundary.toApiEntity(domainEvent);
+        EventApiEntity event = eventBoundary.toApiEntity(domainEvent);
         return event;
     }
 }

--- a/dropwizard-app/src/main/java/org/coner/resource/EventsResource.java
+++ b/dropwizard-app/src/main/java/org/coner/resource/EventsResource.java
@@ -1,9 +1,10 @@
 package org.coner.resource;
 
-import org.coner.api.entity.Event;
+import org.coner.api.entity.EventApiEntity;
 import org.coner.api.response.*;
 import org.coner.boundary.EventBoundary;
 import org.coner.core.ConerCoreService;
+import org.coner.core.domain.Event;
 
 import com.wordnik.swagger.annotations.*;
 import io.dropwizard.hibernate.UnitOfWork;
@@ -31,7 +32,7 @@ public class EventsResource {
     @UnitOfWork
     @ApiOperation(value = "Get a list of all events", response = GetEventsResponse.class)
     public GetEventsResponse getEvents() {
-        List<org.coner.core.domain.Event> domainEvents = conerCoreService.getEvents();
+        List<Event> domainEvents = conerCoreService.getEvents();
         GetEventsResponse response = new GetEventsResponse();
         response.setEvents(eventBoundary.toApiEntities(domainEvents));
         return response;
@@ -53,9 +54,9 @@ public class EventsResource {
             )
     })
     public Response addEvent(
-            @Valid @ApiParam(value = "Event", required = true) Event event
+            @Valid @ApiParam(value = "Event", required = true) EventApiEntity event
     ) {
-        org.coner.core.domain.Event domainEvent = eventBoundary.toDomainEntity(event);
+        Event domainEvent = eventBoundary.toDomainEntity(event);
         conerCoreService.addEvent(domainEvent);
         return Response.created(UriBuilder.fromResource(EventResource.class)
                 .build(domainEvent.getId()))

--- a/dropwizard-app/src/main/java/org/coner/resource/HandicapGroupResource.java
+++ b/dropwizard-app/src/main/java/org/coner/resource/HandicapGroupResource.java
@@ -1,9 +1,10 @@
 package org.coner.resource;
 
-import org.coner.api.entity.HandicapGroup;
+import org.coner.api.entity.HandicapGroupApiEntity;
 import org.coner.api.response.ErrorsResponse;
 import org.coner.boundary.HandicapGroupBoundary;
 import org.coner.core.ConerCoreService;
+import org.coner.core.domain.HandicapGroup;
 
 import com.wordnik.swagger.annotations.*;
 import io.dropwizard.hibernate.UnitOfWork;
@@ -27,19 +28,19 @@ public class HandicapGroupResource {
 
     @GET
     @UnitOfWork
-    @ApiOperation(value = "Get a Handicap Group", response = HandicapGroup.class)
+    @ApiOperation(value = "Get a Handicap Group", response = HandicapGroupApiEntity.class)
     @ApiResponses({
-            @ApiResponse(code = HttpStatus.OK_200, response = HandicapGroup.class, message = "OK"),
+            @ApiResponse(code = HttpStatus.OK_200, response = HandicapGroupApiEntity.class, message = "OK"),
             @ApiResponse(code = HttpStatus.NOT_FOUND_404, response = ErrorsResponse.class, message = "Not found")
     })
-    public HandicapGroup getHandicapGroup(
+    public HandicapGroupApiEntity getHandicapGroup(
             @PathParam("handicapGroupId") @ApiParam(value = "Handicap Group ID", required = true) String id
     ) {
-        org.coner.core.domain.HandicapGroup domainHandicapGroup = conerCoreService.getHandicapGroup(id);
+        HandicapGroup domainHandicapGroup = conerCoreService.getHandicapGroup(id);
         if (domainHandicapGroup == null) {
             throw new NotFoundException("No handicap group with id " + id);
         }
-        org.coner.api.entity.HandicapGroup handicapGroup = handicapGroupBoundary.toApiEntity(domainHandicapGroup);
+        HandicapGroupApiEntity handicapGroup = handicapGroupBoundary.toApiEntity(domainHandicapGroup);
         return handicapGroup;
     }
 }

--- a/dropwizard-app/src/main/java/org/coner/resource/HandicapGroupSetsResource.java
+++ b/dropwizard-app/src/main/java/org/coner/resource/HandicapGroupSetsResource.java
@@ -4,6 +4,7 @@ import org.coner.api.request.AddHandicapGroupSetRequest;
 import org.coner.api.response.ErrorsResponse;
 import org.coner.boundary.HandicapGroupSetBoundary;
 import org.coner.core.ConerCoreService;
+import org.coner.core.domain.HandicapGroup;
 
 import com.wordnik.swagger.annotations.*;
 import io.dropwizard.hibernate.UnitOfWork;
@@ -58,9 +59,9 @@ public class HandicapGroupSetsResource {
                 .toDomainEntity(request);
         Set<AddHandicapGroupSetRequest.HandicapGroup> apiHandicapGroups = request.getHandicapGroups();
         if (apiHandicapGroups != null) {
-            Set<org.coner.core.domain.HandicapGroup> domainHandicapGroups = new HashSet<>();
+            Set<HandicapGroup> domainHandicapGroups = new HashSet<>();
             for (AddHandicapGroupSetRequest.HandicapGroup apiHandicapGroup : apiHandicapGroups) {
-                org.coner.core.domain.HandicapGroup domainHandicapGroup = conerCoreService.getHandicapGroup(
+                HandicapGroup domainHandicapGroup = conerCoreService.getHandicapGroup(
                         apiHandicapGroup.getId()
                 );
                 if (domainHandicapGroup == null) {

--- a/dropwizard-app/src/main/java/org/coner/resource/HandicapGroupSetsResource.java
+++ b/dropwizard-app/src/main/java/org/coner/resource/HandicapGroupSetsResource.java
@@ -4,7 +4,7 @@ import org.coner.api.request.AddHandicapGroupSetRequest;
 import org.coner.api.response.ErrorsResponse;
 import org.coner.boundary.HandicapGroupSetBoundary;
 import org.coner.core.ConerCoreService;
-import org.coner.core.domain.HandicapGroup;
+import org.coner.core.domain.*;
 
 import com.wordnik.swagger.annotations.*;
 import io.dropwizard.hibernate.UnitOfWork;
@@ -55,8 +55,7 @@ public class HandicapGroupSetsResource {
     public Response add(
             @Valid @NotNull @ApiParam(value = "Handicap Group Set") AddHandicapGroupSetRequest request
     ) {
-        org.coner.core.domain.HandicapGroupSet domainHandicapGroupSet = handicapGroupSetBoundary
-                .toDomainEntity(request);
+        HandicapGroupSet domainHandicapGroupSet = handicapGroupSetBoundary.toDomainEntity(request);
         Set<AddHandicapGroupSetRequest.HandicapGroup> apiHandicapGroups = request.getHandicapGroups();
         if (apiHandicapGroups != null) {
             Set<HandicapGroup> domainHandicapGroups = new HashSet<>();

--- a/dropwizard-app/src/main/java/org/coner/resource/HandicapGroupsResource.java
+++ b/dropwizard-app/src/main/java/org/coner/resource/HandicapGroupsResource.java
@@ -1,9 +1,10 @@
 package org.coner.resource;
 
-import org.coner.api.entity.HandicapGroup;
+import org.coner.api.entity.HandicapGroupApiEntity;
 import org.coner.api.response.*;
 import org.coner.boundary.HandicapGroupBoundary;
 import org.coner.core.ConerCoreService;
+import org.coner.core.domain.HandicapGroup;
 
 import com.wordnik.swagger.annotations.*;
 import io.dropwizard.hibernate.UnitOfWork;
@@ -42,9 +43,9 @@ public class HandicapGroupsResource {
             )
     })
     public Response addHandicapGroup(
-            @Valid @ApiParam(value = "Handicap Group") HandicapGroup handicapGroup
+            @Valid @ApiParam(value = "Handicap Group") HandicapGroupApiEntity handicapGroup
     ) {
-        org.coner.core.domain.HandicapGroup domainHandicapGroup = handicapGroupBoundary.toDomainEntity(handicapGroup);
+        HandicapGroup domainHandicapGroup = handicapGroupBoundary.toDomainEntity(handicapGroup);
         conerCoreService.addHandicapGroup(domainHandicapGroup);
         return Response.created(UriBuilder.fromResource(HandicapGroupResource.class)
                 .build(domainHandicapGroup.getId()))
@@ -55,7 +56,7 @@ public class HandicapGroupsResource {
     @UnitOfWork
     @ApiOperation(value = "Get all Handicap Groups", response = GetHandicapGroupsResponse.class)
     public GetHandicapGroupsResponse getHandicapGroups() {
-        List<org.coner.core.domain.HandicapGroup> domainHandicapGroups = conerCoreService.getHandicapGroups();
+        List<HandicapGroup> domainHandicapGroups = conerCoreService.getHandicapGroups();
         GetHandicapGroupsResponse response = new GetHandicapGroupsResponse();
         response.setHandicapGroups(handicapGroupBoundary.toApiEntities(domainHandicapGroups));
         return response;

--- a/dropwizard-app/src/test/java/org/coner/api/entity/CompetitionGroupApiEntityTest.java
+++ b/dropwizard-app/src/test/java/org/coner/api/entity/CompetitionGroupApiEntityTest.java
@@ -9,37 +9,41 @@ import org.assertj.core.api.Assertions;
 import org.junit.*;
 import org.skyscreamer.jsonassert.JSONAssert;
 
-public class CompetitionGroupEntityTest {
+public class CompetitionGroupApiEntityTest {
     private final String fixturePath = "fixtures/api/entity/competition_group_full.json";
 
     private ObjectMapper objectMapper;
-    private CompetitionGroup competitionGroup;
+    private CompetitionGroupApiEntity competitionGroupApiEntity;
 
     @Before
     public void setup() {
         objectMapper = Jackson.newObjectMapper();
         JacksonUtil.configureObjectMapper(objectMapper);
 
-        competitionGroup = ApiEntityTestUtils.fullCompetitionGroup();
+        competitionGroupApiEntity = ApiEntityTestUtils.fullCompetitionGroup();
     }
 
     @Test
     public void deserializesFromJson() throws Exception {
-        CompetitionGroup actual = objectMapper.readValue(FixtureHelpers.fixture(fixturePath), CompetitionGroup.class);
-        Assertions.assertThat(actual).isEqualTo(competitionGroup);
+        CompetitionGroupApiEntity actual = objectMapper.readValue(
+                FixtureHelpers.fixture(fixturePath),
+                CompetitionGroupApiEntity.class
+        );
+        Assertions.assertThat(actual).isEqualTo(competitionGroupApiEntity);
     }
 
     @Test
     public void serializesToJson() throws Exception {
-        String actual = objectMapper.writeValueAsString(competitionGroup);
+        String actual = objectMapper.writeValueAsString(competitionGroupApiEntity);
         String expected = FixtureHelpers.fixture(fixturePath);
         JSONAssert.assertEquals(expected, actual, false);
     }
 
     @Test
     public void hashCodeTest() throws Exception {
-        CompetitionGroup otherCompetitionGroup = ApiEntityTestUtils.fullCompetitionGroup();
+        CompetitionGroupApiEntity otherCompetitionGroupApiEntity = ApiEntityTestUtils.fullCompetitionGroup();
 
-        Assertions.assertThat(competitionGroup.hashCode()).isEqualTo(otherCompetitionGroup.hashCode());
+        Assertions.assertThat(competitionGroupApiEntity.hashCode())
+                .isEqualTo(otherCompetitionGroupApiEntity.hashCode());
     }
 }

--- a/dropwizard-app/src/test/java/org/coner/api/entity/EventApiEntityTest.java
+++ b/dropwizard-app/src/test/java/org/coner/api/entity/EventApiEntityTest.java
@@ -10,12 +10,12 @@ import org.skyscreamer.jsonassert.JSONAssert;
 import static io.dropwizard.testing.FixtureHelpers.fixture;
 import static org.fest.assertions.Assertions.assertThat;
 
-public class EventEntityTest {
+public class EventApiEntityTest {
 
     private final String fixturePath = "fixtures/api/entity/event_full.json";
 
     private ObjectMapper objectMapper;
-    private Event event;
+    private EventApiEntity event;
 
     @Before
     public void setup() {
@@ -27,7 +27,7 @@ public class EventEntityTest {
 
     @Test
     public void deserializesFromJson() throws Exception {
-        Event actual = objectMapper.readValue(fixture(fixturePath), Event.class);
+        EventApiEntity actual = objectMapper.readValue(fixture(fixturePath), EventApiEntity.class);
         assertThat(actual).isEqualTo(event);
     }
 

--- a/dropwizard-app/src/test/java/org/coner/api/entity/HandicapGroupApiEntityTest.java
+++ b/dropwizard-app/src/test/java/org/coner/api/entity/HandicapGroupApiEntityTest.java
@@ -10,11 +10,11 @@ import org.skyscreamer.jsonassert.JSONAssert;
 import static io.dropwizard.testing.FixtureHelpers.fixture;
 import static org.fest.assertions.Assertions.assertThat;
 
-public class HandicapGroupEntityTest {
+public class HandicapGroupApiEntityTest {
     private final String fixturePath = "fixtures/api/entity/handicap_group_full.json";
 
     private ObjectMapper objectMapper;
-    private HandicapGroup handicapGroup;
+    private HandicapGroupApiEntity handicapGroup;
 
     @Before
     public void setup() {
@@ -26,7 +26,7 @@ public class HandicapGroupEntityTest {
 
     @Test
     public void deserializesFromJson() throws Exception {
-        HandicapGroup actual = objectMapper.readValue(fixture(fixturePath), HandicapGroup.class);
+        HandicapGroupApiEntity actual = objectMapper.readValue(fixture(fixturePath), HandicapGroupApiEntity.class);
         assertThat(actual).isEqualTo(handicapGroup);
     }
 
@@ -39,7 +39,7 @@ public class HandicapGroupEntityTest {
 
     @Test
     public void hashCodeTest() throws Exception {
-        HandicapGroup otherHandicapGroup = ApiEntityTestUtils.fullHandicapGroup();
+        HandicapGroupApiEntity otherHandicapGroup = ApiEntityTestUtils.fullHandicapGroup();
 
         assertThat(handicapGroup.hashCode()).isEqualTo(otherHandicapGroup.hashCode());
     }

--- a/dropwizard-app/src/test/java/org/coner/api/entity/RegistrationApiEntityTest.java
+++ b/dropwizard-app/src/test/java/org/coner/api/entity/RegistrationApiEntityTest.java
@@ -10,11 +10,11 @@ import org.skyscreamer.jsonassert.JSONAssert;
 import static io.dropwizard.testing.FixtureHelpers.fixture;
 import static org.fest.assertions.Assertions.assertThat;
 
-public class RegistrationEntityTest {
+public class RegistrationApiEntityTest {
     private final String fixturePath = "fixtures/api/entity/registration_full.json";
 
     private ObjectMapper objectMapper;
-    private Registration registration;
+    private RegistrationApiEntity registration;
 
     @Before
     public void setup() {
@@ -26,7 +26,7 @@ public class RegistrationEntityTest {
 
     @Test
     public void deserializesFromJson() throws Exception {
-        Registration actual = objectMapper.readValue(fixture(fixturePath), Registration.class);
+        RegistrationApiEntity actual = objectMapper.readValue(fixture(fixturePath), RegistrationApiEntity.class);
         assertThat(actual).isEqualTo(registration);
     }
 
@@ -39,7 +39,7 @@ public class RegistrationEntityTest {
 
     @Test
     public void hashCodeTest() throws Exception {
-        Registration otherRegistration = ApiEntityTestUtils.fullApiRegistration();
+        RegistrationApiEntity otherRegistration = ApiEntityTestUtils.fullApiRegistration();
 
         assertThat(registration.hashCode()).isEqualTo(otherRegistration.hashCode());
     }

--- a/dropwizard-app/src/test/java/org/coner/boundary/EventBoundaryTest.java
+++ b/dropwizard-app/src/test/java/org/coner/boundary/EventBoundaryTest.java
@@ -1,6 +1,8 @@
 package org.coner.boundary;
 
+import org.coner.api.entity.EventApiEntity;
 import org.coner.core.domain.Event;
+import org.coner.hibernate.entity.EventHibernateEntity;
 import org.coner.util.*;
 
 import java.util.Date;
@@ -23,7 +25,7 @@ public class EventBoundaryTest {
 
     @Test
     public void whenMergeApiIntoDomainItShouldMerge() {
-        org.coner.api.entity.Event apiEvent = ApiEntityTestUtils.fullApiEvent();
+        EventApiEntity apiEvent = ApiEntityTestUtils.fullApiEvent();
         Event domainEvent = new Event();
 
         eventBoundary.merge(apiEvent, domainEvent);
@@ -37,7 +39,7 @@ public class EventBoundaryTest {
 
     @Test
     public void whenMergeApiWithoutDateIntoDomainItShouldBeWithoutDate() {
-        org.coner.api.entity.Event apiEvent = ApiEntityTestUtils.fullApiEvent();
+        EventApiEntity apiEvent = ApiEntityTestUtils.fullApiEvent();
         apiEvent.setDate(null);
         Event domainEvent = new Event();
 
@@ -49,7 +51,7 @@ public class EventBoundaryTest {
     @Test
     public void whenMergeDomainIntoApiItShouldMerge() {
         Event domainEvent = DomainEntityTestUtils.fullDomainEvent();
-        org.coner.api.entity.Event apiEvent = new org.coner.api.entity.Event();
+        EventApiEntity apiEvent = new EventApiEntity();
 
         eventBoundary.merge(domainEvent, apiEvent);
 
@@ -63,7 +65,7 @@ public class EventBoundaryTest {
     public void whenMergeDomainWithoutDateIntoDomainItShouldBeWithoutDate() {
         Event domainEvent = DomainEntityTestUtils.fullDomainEvent();
         domainEvent.setDate(null);
-        org.coner.api.entity.Event apiEvent = new org.coner.api.entity.Event();
+        EventApiEntity apiEvent = new EventApiEntity();
 
         eventBoundary.merge(domainEvent, apiEvent);
 
@@ -73,7 +75,7 @@ public class EventBoundaryTest {
     @Test
     public void whenMergeDomainIntoHibernateItShouldMerge() {
         Event domainEvent = DomainEntityTestUtils.fullDomainEvent();
-        org.coner.hibernate.entity.Event hibernateEvent = new org.coner.hibernate.entity.Event();
+        EventHibernateEntity hibernateEvent = new EventHibernateEntity();
 
         eventBoundary.merge(domainEvent, hibernateEvent);
 
@@ -87,7 +89,7 @@ public class EventBoundaryTest {
     public void whenMergeDomainWithoutDateIntoHibernateItShouldBeWithoutDate() {
         Event domainEvent = DomainEntityTestUtils.fullDomainEvent();
         domainEvent.setDate(null);
-        org.coner.hibernate.entity.Event hibernateEvent = new org.coner.hibernate.entity.Event();
+        EventHibernateEntity hibernateEvent = new EventHibernateEntity();
 
         eventBoundary.merge(domainEvent, hibernateEvent);
 
@@ -97,7 +99,7 @@ public class EventBoundaryTest {
 
     @Test
     public void whenMergeHibernateIntoDomainItShouldMerge() {
-        org.coner.hibernate.entity.Event hibernateEvent = HibernateEntityUtils.fullHibernateEvent();
+        EventHibernateEntity hibernateEvent = HibernateEntityUtils.fullHibernateEvent();
         Event domainEvent = new Event();
 
         eventBoundary.merge(hibernateEvent, domainEvent);

--- a/dropwizard-app/src/test/java/org/coner/boundary/RegistrationBoundaryTest.java
+++ b/dropwizard-app/src/test/java/org/coner/boundary/RegistrationBoundaryTest.java
@@ -1,5 +1,6 @@
 package org.coner.boundary;
 
+import org.coner.api.entity.RegistrationApiEntity;
 import org.coner.core.domain.Registration;
 import org.coner.util.*;
 
@@ -25,7 +26,7 @@ public class RegistrationBoundaryTest {
 
     @Test
     public void whenMergeApiIntoDomainItShouldMerge() {
-        org.coner.api.entity.Registration apiRegistration = ApiEntityTestUtils.fullApiRegistration();
+        RegistrationApiEntity apiRegistration = ApiEntityTestUtils.fullApiRegistration();
         Registration domainRegistration = new Registration();
 
         registrationBoundary.merge(apiRegistration, domainRegistration);
@@ -38,7 +39,7 @@ public class RegistrationBoundaryTest {
     @Test
     public void whenMergeDomainIntoApiItShouldMerge() {
         Registration domainRegistration = DomainEntityTestUtils.fullDomainRegistration();
-        org.coner.api.entity.Registration apiRegistration = new org.coner.api.entity.Registration();
+        RegistrationApiEntity apiRegistration = new RegistrationApiEntity();
 
         registrationBoundary.merge(domainRegistration, apiRegistration);
 

--- a/dropwizard-app/src/test/java/org/coner/core/gateway/EventGatewayTest.java
+++ b/dropwizard-app/src/test/java/org/coner/core/gateway/EventGatewayTest.java
@@ -4,6 +4,7 @@ package org.coner.core.gateway;
 import org.coner.boundary.EventBoundary;
 import org.coner.core.domain.Event;
 import org.coner.hibernate.dao.EventDao;
+import org.coner.hibernate.entity.EventHibernateEntity;
 
 import java.util.*;
 import org.junit.*;
@@ -36,12 +37,12 @@ public class EventGatewayTest {
 
     @Test
     public void whenGetAllItShouldFindAllAndConvertToDomainEntities() {
-        List<org.coner.hibernate.entity.Event> hibernateEvents = new ArrayList<>();
+        List<EventHibernateEntity> hibernateEvents = new ArrayList<>();
         List<Event> expected = new ArrayList<>();
         when(eventDao.findAll()).thenReturn(hibernateEvents);
         when(eventBoundary.toDomainEntities(hibernateEvents)).thenReturn(expected);
 
-        List<org.coner.core.domain.Event> actual = eventGateway.getAll();
+        List<Event> actual = eventGateway.getAll();
 
         verify(eventDao).findAll();
         verify(eventBoundary).toDomainEntities(hibernateEvents);
@@ -53,7 +54,7 @@ public class EventGatewayTest {
     @Test
     public void whenFindByIdItShouldFindAndConvertToDomainEntity() {
         String id = "test-id";
-        org.coner.hibernate.entity.Event hibernateEvent = mock(org.coner.hibernate.entity.Event.class);
+        EventHibernateEntity hibernateEvent = mock(EventHibernateEntity.class);
         Event expected = mock(Event.class);
         when(eventDao.findById(id)).thenReturn(hibernateEvent);
         when(eventBoundary.toDomainEntity(hibernateEvent)).thenReturn(expected);
@@ -85,7 +86,7 @@ public class EventGatewayTest {
     @Test
     public void whenCreateItShouldConvertToHibernateAndCreateAndMergeHibernateIntoDomain() {
         Event event = mock(Event.class);
-        org.coner.hibernate.entity.Event hibernateEvent = mock(org.coner.hibernate.entity.Event.class);
+        EventHibernateEntity hibernateEvent = mock(EventHibernateEntity.class);
         when(eventBoundary.toHibernateEntity(event)).thenReturn(hibernateEvent);
 
         eventGateway.create(event);

--- a/dropwizard-app/src/test/java/org/coner/hibernate/dao/AbstractDaoTest.java
+++ b/dropwizard-app/src/test/java/org/coner/hibernate/dao/AbstractDaoTest.java
@@ -17,7 +17,7 @@ import org.hibernate.service.ServiceRegistry;
 public abstract class AbstractDaoTest {
 
     private final Class<? extends HibernateEntity>[] hibernateEntityClasses = new Class[]{
-            Event.class,
+            EventHibernateEntity.class,
             RegistrationHibernateEntity.class,
     };
 

--- a/dropwizard-app/src/test/java/org/coner/hibernate/dao/AbstractDaoTest.java
+++ b/dropwizard-app/src/test/java/org/coner/hibernate/dao/AbstractDaoTest.java
@@ -18,7 +18,7 @@ public abstract class AbstractDaoTest {
 
     private final Class<? extends HibernateEntity>[] hibernateEntityClasses = new Class[]{
             Event.class,
-            Registration.class,
+            RegistrationHibernateEntity.class,
     };
 
     private SessionFactory sessionFactory;

--- a/dropwizard-app/src/test/java/org/coner/hibernate/dao/EventDaoTest.java
+++ b/dropwizard-app/src/test/java/org/coner/hibernate/dao/EventDaoTest.java
@@ -1,6 +1,6 @@
 package org.coner.hibernate.dao;
 
-import org.coner.hibernate.entity.Event;
+import org.coner.hibernate.entity.EventHibernateEntity;
 
 import java.time.ZonedDateTime;
 import java.util.*;
@@ -21,7 +21,7 @@ public class EventDaoTest extends AbstractDaoTest {
 
         getSession().beginTransaction();
 
-        Query delete = getSession().createQuery("delete from Event");
+        Query delete = getSession().createQuery("delete from EventHibernateEntity");
         delete.executeUpdate();
 
         getSession().getTransaction().commit();
@@ -35,7 +35,7 @@ public class EventDaoTest extends AbstractDaoTest {
     public void whenFindAllItShouldReturnEmpty() {
         getSession().beginTransaction();
 
-        List<Event> actual = eventDao.findAll();
+        List<EventHibernateEntity> actual = eventDao.findAll();
         assertThat(actual)
                 .isNotNull()
                 .isEmpty();
@@ -45,7 +45,7 @@ public class EventDaoTest extends AbstractDaoTest {
 
     @Test
     public void whenCreateItShouldCreateEvent() {
-        Event newEvent = buildNewEvent();
+        EventHibernateEntity newEvent = buildNewEvent();
 
         getSession().beginTransaction();
 
@@ -59,14 +59,14 @@ public class EventDaoTest extends AbstractDaoTest {
 
     @Test
     public void whenCreatedItShouldFindById() {
-        Event newEvent = buildNewEvent();
+        EventHibernateEntity newEvent = buildNewEvent();
         getSession().beginTransaction();
         eventDao.create(newEvent);
         getSession().getTransaction().commit();
 
         getSession().beginTransaction();
 
-        Event actual = eventDao.findById(newEvent.getId());
+        EventHibernateEntity actual = eventDao.findById(newEvent.getId());
 
         getSession().getTransaction().commit();
 
@@ -77,14 +77,14 @@ public class EventDaoTest extends AbstractDaoTest {
 
     @Test
     public void whenCreateItShouldBeInFindAll() {
-        Event newEvent = buildNewEvent();
+        EventHibernateEntity newEvent = buildNewEvent();
         getSession().beginTransaction();
         eventDao.create(newEvent);
         getSession().getTransaction().commit();
 
         getSession().beginTransaction();
 
-        List<Event> events = eventDao.findAll();
+        List<EventHibernateEntity> events = eventDao.findAll();
 
         getSession().getTransaction().commit();
 
@@ -94,8 +94,8 @@ public class EventDaoTest extends AbstractDaoTest {
                 .containsOnly(newEvent);
     }
 
-    private Event buildNewEvent() {
-        Event event = new Event();
+    private EventHibernateEntity buildNewEvent() {
+        EventHibernateEntity event = new EventHibernateEntity();
         event.setName(name);
         event.setDate(date);
         assertThat(event.getId()).isNull();

--- a/dropwizard-app/src/test/java/org/coner/it/CompetitionGroupIntegrationTest.java
+++ b/dropwizard-app/src/test/java/org/coner/it/CompetitionGroupIntegrationTest.java
@@ -1,6 +1,6 @@
 package org.coner.it;
 
-import org.coner.api.entity.CompetitionGroup;
+import org.coner.api.entity.CompetitionGroupApiEntity;
 import org.coner.api.request.*;
 import org.coner.api.response.ErrorsResponse;
 import org.coner.util.*;
@@ -49,8 +49,8 @@ public class CompetitionGroupIntegrationTest extends AbstractIntegrationTest {
                 .get();
 
         assertThat(getCompetitionGroupResponseContainer.getStatus()).isEqualTo(HttpStatus.OK_200);
-        CompetitionGroup getCompetitionGroupResponse = getCompetitionGroupResponseContainer
-                .readEntity(CompetitionGroup.class);
+        CompetitionGroupApiEntity getCompetitionGroupResponse = getCompetitionGroupResponseContainer
+                .readEntity(CompetitionGroupApiEntity.class);
         assertThat(getCompetitionGroupResponse.getId()).isEqualTo(competitionGroupId);
     }
 

--- a/dropwizard-app/src/test/java/org/coner/it/EventIntegrationTest.java
+++ b/dropwizard-app/src/test/java/org/coner/it/EventIntegrationTest.java
@@ -1,6 +1,6 @@
 package org.coner.it;
 
-import org.coner.api.entity.Event;
+import org.coner.api.entity.EventApiEntity;
 import org.coner.api.request.AddEventRequest;
 import org.coner.api.response.*;
 import org.coner.util.UnitTestUtils;
@@ -45,7 +45,7 @@ public class EventIntegrationTest extends AbstractIntegrationTest {
         assertThat(getEventsResponseContainer.getStatus()).isEqualTo(HttpStatus.OK_200);
         GetEventsResponse getEventsResponse = getEventsResponseContainer.readEntity(GetEventsResponse.class);
         assertThat(getEventsResponse.getEvents()).hasSize(1);
-        Event event = getEventsResponse.getEvents().get(0);
+        EventApiEntity event = getEventsResponse.getEvents().get(0);
         assertThat(event.getId()).isEqualTo(eventId);
 
         URI getEventByIdUri = IntegrationTestUtils.jerseyUriBuilderForApp(RULE)
@@ -58,7 +58,7 @@ public class EventIntegrationTest extends AbstractIntegrationTest {
                 .get();
 
         assertThat(getEventByIdResponseContainer.getStatus()).isEqualTo(HttpStatus.OK_200);
-        Event getEventByIdResponse = getEventByIdResponseContainer.readEntity(Event.class);
+        EventApiEntity getEventByIdResponse = getEventByIdResponseContainer.readEntity(EventApiEntity.class);
         assertThat(getEventByIdResponse.getId()).isEqualTo(eventId);
     }
 

--- a/dropwizard-app/src/test/java/org/coner/it/HandicapGroupIntegrationTest.java
+++ b/dropwizard-app/src/test/java/org/coner/it/HandicapGroupIntegrationTest.java
@@ -1,6 +1,6 @@
 package org.coner.it;
 
-import org.coner.api.entity.HandicapGroup;
+import org.coner.api.entity.HandicapGroupApiEntity;
 import org.coner.api.request.AddHandicapGroupRequest;
 import org.coner.api.request.AddHandicapGroupSetRequest;
 import org.coner.api.response.ErrorsResponse;
@@ -48,8 +48,8 @@ public class HandicapGroupIntegrationTest extends AbstractIntegrationTest {
                 .get();
 
         assertThat(getHandicapGroupResponseContainer.getStatus()).isEqualTo(HttpStatus.OK_200);
-        HandicapGroup getHandicapGroupResponse = getHandicapGroupResponseContainer
-                .readEntity(HandicapGroup.class);
+        HandicapGroupApiEntity getHandicapGroupResponse = getHandicapGroupResponseContainer
+                .readEntity(HandicapGroupApiEntity.class);
         assertThat(getHandicapGroupResponse.getId()).isEqualTo(handicapGroupId);
     }
 

--- a/dropwizard-app/src/test/java/org/coner/it/RegistrationIntegrationTest.java
+++ b/dropwizard-app/src/test/java/org/coner/it/RegistrationIntegrationTest.java
@@ -1,6 +1,6 @@
 package org.coner.it;
 
-import org.coner.api.entity.Registration;
+import org.coner.api.entity.RegistrationApiEntity;
 import org.coner.api.request.*;
 import org.coner.api.response.*;
 import org.coner.util.*;
@@ -100,7 +100,7 @@ public class RegistrationIntegrationTest extends AbstractIntegrationTest {
         GetEventRegistrationsResponse getEventRegistrationsResponse = getRegistrationsResponseContainer
                 .readEntity(GetEventRegistrationsResponse.class);
         assertThat(getEventRegistrationsResponse).isNotNull();
-        List<Registration> registrationList = getEventRegistrationsResponse.getRegistrations();
+        List<RegistrationApiEntity> registrationList = getEventRegistrationsResponse.getRegistrations();
         assertThat(registrationList.size()).isEqualTo(2);
         assertThat(registrationList.get(0).getId())
                 .isNotEqualTo(registrationList.get(1).getId())
@@ -120,8 +120,8 @@ public class RegistrationIntegrationTest extends AbstractIntegrationTest {
 
         assertThat(getRegistrationResponse.getStatus()).isEqualTo(HttpStatus.OK_200);
 
-        Registration registration = getRegistrationResponse
-                .readEntity(Registration.class);
+        RegistrationApiEntity registration = getRegistrationResponse
+                .readEntity(RegistrationApiEntity.class);
         assertThat(registration).isNotNull();
         assertThat(registration.getId()).isEqualTo(registrationId0);
 

--- a/dropwizard-app/src/test/java/org/coner/resource/CompetitionGroupResourceTest.java
+++ b/dropwizard-app/src/test/java/org/coner/resource/CompetitionGroupResourceTest.java
@@ -1,6 +1,6 @@
 package org.coner.resource;
 
-import org.coner.api.entity.CompetitionGroup;
+import org.coner.api.entity.CompetitionGroupApiEntity;
 import org.coner.boundary.CompetitionGroupBoundary;
 import org.coner.core.ConerCoreService;
 import org.coner.util.*;
@@ -38,16 +38,16 @@ public class CompetitionGroupResourceTest {
     @Test
     public void itShouldGetCompetitionGroup() {
         org.coner.core.domain.CompetitionGroup domainCompetitionGroup = DomainEntityTestUtils.fullCompetitionGroup();
-        org.coner.api.entity.CompetitionGroup apiCompetitionGroup = ApiEntityTestUtils.fullCompetitionGroup();
+        CompetitionGroupApiEntity competitionGroupApiEntity = ApiEntityTestUtils.fullCompetitionGroup();
 
         // sanity check test
         assertThat(domainCompetitionGroup.getId()).isSameAs(TestConstants.COMPETITION_GROUP_ID);
-        assertThat(apiCompetitionGroup.getId()).isSameAs(TestConstants.COMPETITION_GROUP_ID);
+        assertThat(competitionGroupApiEntity.getId()).isSameAs(TestConstants.COMPETITION_GROUP_ID);
 
         when(conerCoreService.getCompetitionGroup(TestConstants.COMPETITION_GROUP_ID))
                 .thenReturn(domainCompetitionGroup);
         when(competitionGroupBoundary.toApiEntity(domainCompetitionGroup))
-                .thenReturn(apiCompetitionGroup);
+                .thenReturn(competitionGroupApiEntity);
 
         Response competitionGroupResourceContainer = resources.client()
                 .target("/competitionGroups/" + TestConstants.COMPETITION_GROUP_ID)
@@ -61,12 +61,12 @@ public class CompetitionGroupResourceTest {
         assertThat(competitionGroupResourceContainer).isNotNull();
         assertThat(competitionGroupResourceContainer.getStatus()).isEqualTo(HttpStatus.OK_200);
 
-        CompetitionGroup getCompetitionGroupResponse = competitionGroupResourceContainer.readEntity(
-                CompetitionGroup.class
+        CompetitionGroupApiEntity getCompetitionGroupResponse = competitionGroupResourceContainer.readEntity(
+                CompetitionGroupApiEntity.class
         );
         assertThat(getCompetitionGroupResponse)
                 .isNotNull()
-                .isEqualTo(apiCompetitionGroup);
+                .isEqualTo(competitionGroupApiEntity);
     }
 
     @Test

--- a/dropwizard-app/src/test/java/org/coner/resource/CompetitionGroupResourceTest.java
+++ b/dropwizard-app/src/test/java/org/coner/resource/CompetitionGroupResourceTest.java
@@ -3,6 +3,7 @@ package org.coner.resource;
 import org.coner.api.entity.CompetitionGroupApiEntity;
 import org.coner.boundary.CompetitionGroupBoundary;
 import org.coner.core.ConerCoreService;
+import org.coner.core.domain.CompetitionGroup;
 import org.coner.util.*;
 
 import io.dropwizard.jersey.validation.ConstraintViolationExceptionMapper;
@@ -37,7 +38,7 @@ public class CompetitionGroupResourceTest {
 
     @Test
     public void itShouldGetCompetitionGroup() {
-        org.coner.core.domain.CompetitionGroup domainCompetitionGroup = DomainEntityTestUtils.fullCompetitionGroup();
+        CompetitionGroup domainCompetitionGroup = DomainEntityTestUtils.fullCompetitionGroup();
         CompetitionGroupApiEntity competitionGroupApiEntity = ApiEntityTestUtils.fullCompetitionGroup();
 
         // sanity check test

--- a/dropwizard-app/src/test/java/org/coner/resource/CompetitionGroupsResourceTest.java
+++ b/dropwizard-app/src/test/java/org/coner/resource/CompetitionGroupsResourceTest.java
@@ -1,5 +1,6 @@
 package org.coner.resource;
 
+import org.coner.api.entity.CompetitionGroupApiEntity;
 import org.coner.api.response.*;
 import org.coner.boundary.CompetitionGroupBoundary;
 import org.coner.core.ConerCoreService;
@@ -26,9 +27,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-/**
- *
- */
 public class CompetitionGroupsResourceTest {
 
     private CompetitionGroupBoundary competitionGroupBoundary = mock(CompetitionGroupBoundary.class);
@@ -62,11 +60,11 @@ public class CompetitionGroupsResourceTest {
 
     @Test
     public void whenAddCompetitionGroupWithUserSuppliedIdItShouldFailValidation() throws Exception {
-        org.coner.api.entity.CompetitionGroup requestCompetitionGroup = objectMapper.readValue(
+        CompetitionGroupApiEntity requestCompetitionGroupApiEntity = objectMapper.readValue(
                 fixture("fixtures/api/entity/competition_group_add-request-with-id.json"),
-                org.coner.api.entity.CompetitionGroup.class
+                CompetitionGroupApiEntity.class
         );
-        Entity<org.coner.api.entity.CompetitionGroup> requestEntity = Entity.json(requestCompetitionGroup);
+        Entity<CompetitionGroupApiEntity> requestEntity = Entity.json(requestCompetitionGroupApiEntity);
 
         Response response = resources.client()
                 .target("/competitionGroups")
@@ -85,11 +83,11 @@ public class CompetitionGroupsResourceTest {
 
     @Test
     public void whenAddCompetitionGroupWithLargeHandicapFactorItShouldFailValidation() throws Exception {
-        org.coner.api.entity.CompetitionGroup requestCompetitionGroup = objectMapper.readValue(
+        CompetitionGroupApiEntity requestCompetitionGroupApiEntity = objectMapper.readValue(
                 fixture("fixtures/api/entity/competition_group_add-request-with-large-handicap-factor.json"),
-                org.coner.api.entity.CompetitionGroup.class
+                CompetitionGroupApiEntity.class
         );
-        Entity<org.coner.api.entity.CompetitionGroup> requestEntity = Entity.json(requestCompetitionGroup);
+        Entity<CompetitionGroupApiEntity> requestEntity = Entity.json(requestCompetitionGroupApiEntity);
 
         Response response = resources.client()
                 .target("/competitionGroups")
@@ -108,11 +106,11 @@ public class CompetitionGroupsResourceTest {
 
     @Test
     public void whenAddCompetitionGroupWithoutResultTimeTypeItShouldFailValidation() throws Exception {
-        org.coner.api.entity.CompetitionGroup requestCompetitionGroup = objectMapper.readValue(
+        CompetitionGroupApiEntity requestCompetitionGroupApiEntity = objectMapper.readValue(
                 fixture("fixtures/api/entity/competition_group_add-request-without-result-time-type.json"),
-                org.coner.api.entity.CompetitionGroup.class
+                CompetitionGroupApiEntity.class
         );
-        Entity<org.coner.api.entity.CompetitionGroup> requestEntity = Entity.json(requestCompetitionGroup);
+        Entity<CompetitionGroupApiEntity> requestEntity = Entity.json(requestCompetitionGroupApiEntity);
 
         Response response = resources.client()
                 .target("/competitionGroups")
@@ -131,11 +129,11 @@ public class CompetitionGroupsResourceTest {
 
     @Test
     public void whenAddCompetitionGroupWithoutGroupingItShouldFailValidation() throws Exception {
-        org.coner.api.entity.CompetitionGroup requestCompetitionGroup = objectMapper.readValue(
+        CompetitionGroupApiEntity requestCompetitionGroupApiEntity = objectMapper.readValue(
                 fixture("fixtures/api/entity/competition_group_add-request-without-grouping.json"),
-                org.coner.api.entity.CompetitionGroup.class
+                CompetitionGroupApiEntity.class
         );
-        Entity<org.coner.api.entity.CompetitionGroup> requestEntity = Entity.json(requestCompetitionGroup);
+        Entity<CompetitionGroupApiEntity> requestEntity = Entity.json(requestCompetitionGroupApiEntity);
 
         Response response = resources.client()
                 .target("/competitionGroups")
@@ -158,13 +156,13 @@ public class CompetitionGroupsResourceTest {
 
         List<CompetitionGroup> domainCompetitionGroups = new ArrayList<>();
         domainCompetitionGroups.add(DomainEntityTestUtils.fullCompetitionGroup());
-        List<org.coner.api.entity.CompetitionGroup> apiCompetitionGroups = new ArrayList<>();
-        apiCompetitionGroups.add(ApiEntityTestUtils.fullCompetitionGroup());
+        List<CompetitionGroupApiEntity> competitionGroupApiEntities = new ArrayList<>();
+        competitionGroupApiEntities.add(ApiEntityTestUtils.fullCompetitionGroup());
 
         when(conerCoreService.getCompetitionGroups())
                 .thenReturn(domainCompetitionGroups);
         when(competitionGroupBoundary.toApiEntities(domainCompetitionGroups))
-                .thenReturn(apiCompetitionGroups);
+                .thenReturn(competitionGroupApiEntities);
 
         GetCompetitionGroupsResponse response = resources.client()
                 .target("/competitionGroups")
@@ -183,18 +181,18 @@ public class CompetitionGroupsResourceTest {
     }
 
     private Response postCompetitionGroup() throws Exception {
-        org.coner.api.entity.CompetitionGroup requestCompetitionGroup = objectMapper.readValue(
+        CompetitionGroupApiEntity requestCompetitionGroupApiEntity = objectMapper.readValue(
                 fixture("fixtures/api/entity/competition_group_add-request.json"),
-                org.coner.api.entity.CompetitionGroup.class
+                CompetitionGroupApiEntity.class
         );
 
-        Entity<org.coner.api.entity.CompetitionGroup> requestEntity = Entity.json(requestCompetitionGroup);
+        Entity<CompetitionGroupApiEntity> requestEntity = Entity.json(requestCompetitionGroupApiEntity);
 
         org.coner.core.domain.CompetitionGroup requestCompetitionGroupAsDomain =
                 new org.coner.core.domain.CompetitionGroup();
         requestCompetitionGroupAsDomain.setId("arbitrary-id-from-service");
 
-        when(competitionGroupBoundary.toDomainEntity(requestCompetitionGroup))
+        when(competitionGroupBoundary.toDomainEntity(requestCompetitionGroupApiEntity))
                 .thenReturn(requestCompetitionGroupAsDomain);
 
         Response response = resources.client()
@@ -202,7 +200,7 @@ public class CompetitionGroupsResourceTest {
                 .request(MediaType.APPLICATION_JSON_TYPE)
                 .post(requestEntity);
 
-        verify(competitionGroupBoundary).toDomainEntity(requestCompetitionGroup);
+        verify(competitionGroupBoundary).toDomainEntity(requestCompetitionGroupApiEntity);
         verify(conerCoreService).addCompetitionGroup(requestCompetitionGroupAsDomain);
         verifyNoMoreInteractions(conerCoreService, competitionGroupBoundary);
 

--- a/dropwizard-app/src/test/java/org/coner/resource/CompetitionGroupsResourceTest.java
+++ b/dropwizard-app/src/test/java/org/coner/resource/CompetitionGroupsResourceTest.java
@@ -78,7 +78,7 @@ public class CompetitionGroupsResourceTest {
                 .isNotEmpty()
                 .contains("id competitionGroup.id may only be assigned by the system (was bad-id-in-request)");
 
-        verify(conerCoreService, never()).addCompetitionGroup(any(org.coner.core.domain.CompetitionGroup.class));
+        verify(conerCoreService, never()).addCompetitionGroup(any(CompetitionGroup.class));
     }
 
     @Test
@@ -188,12 +188,11 @@ public class CompetitionGroupsResourceTest {
 
         Entity<CompetitionGroupApiEntity> requestEntity = Entity.json(requestCompetitionGroupApiEntity);
 
-        org.coner.core.domain.CompetitionGroup requestCompetitionGroupAsDomain =
-                new org.coner.core.domain.CompetitionGroup();
-        requestCompetitionGroupAsDomain.setId("arbitrary-id-from-service");
+        CompetitionGroup requestCompetitionGroupDomainEntity = new CompetitionGroup();
+        requestCompetitionGroupDomainEntity.setId("arbitrary-id-from-service");
 
         when(competitionGroupBoundary.toDomainEntity(requestCompetitionGroupApiEntity))
-                .thenReturn(requestCompetitionGroupAsDomain);
+                .thenReturn(requestCompetitionGroupDomainEntity);
 
         Response response = resources.client()
                 .target("/competitionGroups")
@@ -201,7 +200,7 @@ public class CompetitionGroupsResourceTest {
                 .post(requestEntity);
 
         verify(competitionGroupBoundary).toDomainEntity(requestCompetitionGroupApiEntity);
-        verify(conerCoreService).addCompetitionGroup(requestCompetitionGroupAsDomain);
+        verify(conerCoreService).addCompetitionGroup(requestCompetitionGroupDomainEntity);
         verifyNoMoreInteractions(conerCoreService, competitionGroupBoundary);
 
         return response;

--- a/dropwizard-app/src/test/java/org/coner/resource/EventRegistrationResourceTest.java
+++ b/dropwizard-app/src/test/java/org/coner/resource/EventRegistrationResourceTest.java
@@ -3,7 +3,7 @@ package org.coner.resource;
 import org.coner.api.entity.RegistrationApiEntity;
 import org.coner.boundary.*;
 import org.coner.core.ConerCoreService;
-import org.coner.core.domain.Registration;
+import org.coner.core.domain.*;
 import org.coner.core.exception.EventRegistrationMismatchException;
 import org.coner.util.*;
 
@@ -40,7 +40,7 @@ public class EventRegistrationResourceTest {
 
     @Test
     public void itShouldGetRegistration() throws EventRegistrationMismatchException {
-        org.coner.core.domain.Event domainEvent = DomainEntityTestUtils.fullDomainEvent();
+        Event domainEvent = DomainEntityTestUtils.fullDomainEvent();
         Registration domainRegistration = DomainEntityTestUtils.fullDomainRegistration();
         RegistrationApiEntity apiRegistration = ApiEntityTestUtils.fullApiRegistration();
 

--- a/dropwizard-app/src/test/java/org/coner/resource/EventRegistrationResourceTest.java
+++ b/dropwizard-app/src/test/java/org/coner/resource/EventRegistrationResourceTest.java
@@ -1,8 +1,9 @@
 package org.coner.resource;
 
-import org.coner.api.entity.Registration;
+import org.coner.api.entity.RegistrationApiEntity;
 import org.coner.boundary.*;
 import org.coner.core.ConerCoreService;
+import org.coner.core.domain.Registration;
 import org.coner.core.exception.EventRegistrationMismatchException;
 import org.coner.util.*;
 
@@ -40,8 +41,8 @@ public class EventRegistrationResourceTest {
     @Test
     public void itShouldGetRegistration() throws EventRegistrationMismatchException {
         org.coner.core.domain.Event domainEvent = DomainEntityTestUtils.fullDomainEvent();
-        org.coner.core.domain.Registration domainRegistration = DomainEntityTestUtils.fullDomainRegistration();
-        org.coner.api.entity.Registration apiRegistration = ApiEntityTestUtils.fullApiRegistration();
+        Registration domainRegistration = DomainEntityTestUtils.fullDomainRegistration();
+        RegistrationApiEntity apiRegistration = ApiEntityTestUtils.fullApiRegistration();
 
         // sanity check test
         assertThat(domainEvent.getId()).isSameAs(TestConstants.EVENT_ID);
@@ -52,7 +53,7 @@ public class EventRegistrationResourceTest {
                 .thenReturn(domainRegistration);
         when(registrationBoundary.toApiEntity(domainRegistration)).thenReturn(apiRegistration);
 
-        Response registrationResponseContainer = resources.client()
+        Response responseContainer = resources.client()
                 .target("/events/" + TestConstants.EVENT_ID + "/registrations/" + TestConstants.REGISTRATION_ID)
                 .request(MediaType.APPLICATION_JSON_TYPE)
                 .get();
@@ -62,11 +63,11 @@ public class EventRegistrationResourceTest {
         verifyNoMoreInteractions(conerCoreService, registrationBoundary);
         verifyZeroInteractions(eventBoundary);
 
-        assertThat(registrationResponseContainer).isNotNull();
-        assertThat(registrationResponseContainer.getStatus()).isEqualTo(HttpStatus.OK_200);
+        assertThat(responseContainer).isNotNull();
+        assertThat(responseContainer.getStatus()).isEqualTo(HttpStatus.OK_200);
 
-        Registration registrationResponse = registrationResponseContainer.readEntity(Registration.class);
-        assertThat(registrationResponse)
+        RegistrationApiEntity responseEntity = responseContainer.readEntity(RegistrationApiEntity.class);
+        assertThat(responseEntity)
                 .isNotNull()
                 .isEqualToComparingFieldByField(apiRegistration);
     }

--- a/dropwizard-app/src/test/java/org/coner/resource/EventRegistrationsResourceTest.java
+++ b/dropwizard-app/src/test/java/org/coner/resource/EventRegistrationsResourceTest.java
@@ -4,7 +4,7 @@ import org.coner.api.entity.RegistrationApiEntity;
 import org.coner.api.response.GetEventRegistrationsResponse;
 import org.coner.boundary.*;
 import org.coner.core.ConerCoreService;
-import org.coner.core.domain.Registration;
+import org.coner.core.domain.*;
 import org.coner.util.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -30,7 +30,7 @@ public class EventRegistrationsResourceTest {
     private final EventBoundary eventBoundary = mock(EventBoundary.class);
     private final RegistrationBoundary registrationBoundary = mock(RegistrationBoundary.class);
     private final ConerCoreService conerCoreService = mock(ConerCoreService.class);
-    
+
     private ObjectMapper objectMapper;
 
     @Rule
@@ -52,7 +52,7 @@ public class EventRegistrationsResourceTest {
         // Event
         final String eventId = TestConstants.EVENT_ID;
 
-        org.coner.core.domain.Event domainEvent = DomainEntityTestUtils.fullDomainEvent();
+        Event domainEvent = DomainEntityTestUtils.fullDomainEvent();
 
         // Registrations
         final String registrationID = TestConstants.REGISTRATION_ID;
@@ -101,7 +101,7 @@ public class EventRegistrationsResourceTest {
         requestRegistrationAsDomain.setFirstName(TestConstants.REGISTRATION_FIRSTNAME);
         requestRegistrationAsDomain.setLastName(TestConstants.REGISTRATION_LASTNAME);
 
-        org.coner.core.domain.Event domainEvent = DomainEntityTestUtils.fullDomainEvent();
+        Event domainEvent = DomainEntityTestUtils.fullDomainEvent();
 
         when(registrationBoundary.toDomainEntity(requestRegistration)).thenReturn(requestRegistrationAsDomain);
         when(conerCoreService.getEvent(eventId)).thenReturn(domainEvent);

--- a/dropwizard-app/src/test/java/org/coner/resource/EventRegistrationsResourceTest.java
+++ b/dropwizard-app/src/test/java/org/coner/resource/EventRegistrationsResourceTest.java
@@ -1,8 +1,10 @@
 package org.coner.resource;
 
+import org.coner.api.entity.RegistrationApiEntity;
 import org.coner.api.response.GetEventRegistrationsResponse;
 import org.coner.boundary.*;
 import org.coner.core.ConerCoreService;
+import org.coner.core.domain.Registration;
 import org.coner.util.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -55,11 +57,11 @@ public class EventRegistrationsResourceTest {
         // Registrations
         final String registrationID = TestConstants.REGISTRATION_ID;
 
-        List<org.coner.core.domain.Registration> domainRegistrations = new ArrayList<>();
-        org.coner.core.domain.Registration domainRegistration1 = DomainEntityTestUtils.fullDomainRegistration();
+        List<Registration> domainRegistrations = new ArrayList<>();
+        Registration domainRegistration1 = DomainEntityTestUtils.fullDomainRegistration();
 
-        List<org.coner.api.entity.Registration> apiRegistrations = new ArrayList<>();
-        org.coner.api.entity.Registration apiRegistration1 = ApiEntityTestUtils.fullApiRegistration();
+        List<RegistrationApiEntity> apiRegistrations = new ArrayList<>();
+        RegistrationApiEntity apiRegistration1 = ApiEntityTestUtils.fullApiRegistration();
 
         domainRegistrations.add(domainRegistration1);
         apiRegistrations.add(apiRegistration1);
@@ -88,13 +90,13 @@ public class EventRegistrationsResourceTest {
 
         final String eventId = TestConstants.EVENT_ID;
 
-        org.coner.api.entity.Registration requestRegistration = objectMapper.readValue(
+        RegistrationApiEntity requestRegistration = objectMapper.readValue(
                 FixtureHelpers.fixture("fixtures/api/entity/registration_add-request.json"),
-                org.coner.api.entity.Registration.class
+                RegistrationApiEntity.class
         );
-        Entity<org.coner.api.entity.Registration> requestEntity = Entity.json(requestRegistration);
+        Entity<RegistrationApiEntity> requestEntity = Entity.json(requestRegistration);
 
-        org.coner.core.domain.Registration requestRegistrationAsDomain = new org.coner.core.domain.Registration();
+        Registration requestRegistrationAsDomain = new Registration();
         requestRegistrationAsDomain.setId("arbitrary-id-from-service");
         requestRegistrationAsDomain.setFirstName(TestConstants.REGISTRATION_FIRSTNAME);
         requestRegistrationAsDomain.setLastName(TestConstants.REGISTRATION_LASTNAME);

--- a/dropwizard-app/src/test/java/org/coner/resource/EventResourceTest.java
+++ b/dropwizard-app/src/test/java/org/coner/resource/EventResourceTest.java
@@ -1,8 +1,9 @@
 package org.coner.resource;
 
-import org.coner.api.entity.Event;
+import org.coner.api.entity.EventApiEntity;
 import org.coner.boundary.EventBoundary;
 import org.coner.core.ConerCoreService;
+import org.coner.core.domain.Event;
 import org.coner.util.*;
 
 import io.dropwizard.testing.junit.ResourceTestRule;
@@ -36,8 +37,8 @@ public class EventResourceTest {
 
     @Test
     public void itShouldGetEvent() {
-        org.coner.core.domain.Event domainEvent = DomainEntityTestUtils.fullDomainEvent();
-        Event apiEvent = ApiEntityTestUtils.fullApiEvent();
+        Event domainEvent = DomainEntityTestUtils.fullDomainEvent();
+        EventApiEntity apiEvent = ApiEntityTestUtils.fullApiEvent();
 
         // sanity check test
         assertThat(domainEvent.getId()).isSameAs(TestConstants.EVENT_ID);
@@ -58,7 +59,7 @@ public class EventResourceTest {
         assertThat(getEventResponseContainer).isNotNull();
         assertThat(getEventResponseContainer.getStatus()).isEqualTo(HttpStatus.OK_200);
 
-        Event getEventResponse = getEventResponseContainer.readEntity(Event.class);
+        EventApiEntity getEventResponse = getEventResponseContainer.readEntity(EventApiEntity.class);
         assertThat(getEventResponse)
                 .isNotNull()
                 .isEqualTo(apiEvent);

--- a/dropwizard-app/src/test/java/org/coner/resource/EventsResourceTest.java
+++ b/dropwizard-app/src/test/java/org/coner/resource/EventsResourceTest.java
@@ -1,5 +1,6 @@
 package org.coner.resource;
 
+import org.coner.api.entity.EventApiEntity;
 import org.coner.api.response.*;
 import org.coner.boundary.EventBoundary;
 import org.coner.core.ConerCoreService;
@@ -67,11 +68,11 @@ public class EventsResourceTest {
 
     @Test
     public void whenAddValidEventItShouldAddEvent() throws Exception {
-        org.coner.api.entity.Event requestEvent = objectMapper.readValue(
+        EventApiEntity requestEvent = objectMapper.readValue(
                 FixtureHelpers.fixture("fixtures/api/entity/event_add-request.json"),
-                org.coner.api.entity.Event.class
+                EventApiEntity.class
         );
-        Entity<org.coner.api.entity.Event> requestEntity = Entity.json(requestEvent);
+        Entity<EventApiEntity> requestEntity = Entity.json(requestEvent);
 
         Event requestEventAsDomain = new Event();
         requestEventAsDomain.setId("arbitrary-id-from-service");
@@ -95,11 +96,11 @@ public class EventsResourceTest {
 
     @Test
     public void whenAddEventWithUserSuppliedIdItShouldFailValidation() throws Exception {
-        org.coner.api.entity.Event requestEvent = objectMapper.readValue(
+        EventApiEntity requestEvent = objectMapper.readValue(
                 FixtureHelpers.fixture("fixtures/api/entity/event_add-request-with-id.json"),
-                org.coner.api.entity.Event.class
+                EventApiEntity.class
         );
-        Entity<org.coner.api.entity.Event> requestEntity = Entity.json(requestEvent);
+        Entity<EventApiEntity> requestEntity = Entity.json(requestEvent);
 
         Response response = resources.client()
                 .target("/events")
@@ -116,11 +117,11 @@ public class EventsResourceTest {
 
     @Test
     public void whenAddEventWithoutNameItShouldFailValidation() throws Exception {
-        org.coner.api.entity.Event requestEvent = objectMapper.readValue(
+        EventApiEntity requestEvent = objectMapper.readValue(
                 FixtureHelpers.fixture("fixtures/api/entity/event_add-request-without-name.json"),
-                org.coner.api.entity.Event.class
+                EventApiEntity.class
         );
-        Entity<org.coner.api.entity.Event> requestEntity = Entity.json(requestEvent);
+        Entity<EventApiEntity> requestEntity = Entity.json(requestEvent);
 
         Response response = resources.client()
                 .target("/events")
@@ -136,11 +137,11 @@ public class EventsResourceTest {
 
     @Test
     public void whenAddEventWithoutDateItShouldFailValidation() throws Exception {
-        org.coner.api.entity.Event requestEvent = objectMapper.readValue(
+        EventApiEntity requestEvent = objectMapper.readValue(
                 FixtureHelpers.fixture("fixtures/api/entity/event_add-request-without-date.json"),
-                org.coner.api.entity.Event.class
+                EventApiEntity.class
         );
-        Entity<org.coner.api.entity.Event> requestEntity = Entity.json(requestEvent);
+        Entity<EventApiEntity> requestEntity = Entity.json(requestEvent);
 
 
         Response response = resources.client()

--- a/dropwizard-app/src/test/java/org/coner/resource/HandicapGroupResourceTest.java
+++ b/dropwizard-app/src/test/java/org/coner/resource/HandicapGroupResourceTest.java
@@ -1,8 +1,9 @@
 package org.coner.resource;
 
-import org.coner.api.entity.HandicapGroup;
+import org.coner.api.entity.HandicapGroupApiEntity;
 import org.coner.boundary.HandicapGroupBoundary;
 import org.coner.core.ConerCoreService;
+import org.coner.core.domain.HandicapGroup;
 import org.coner.util.*;
 
 import io.dropwizard.jersey.validation.ConstraintViolationExceptionMapper;
@@ -37,17 +38,17 @@ public class HandicapGroupResourceTest {
 
     @Test
     public void itShouldGetHandicapGroup() {
-        org.coner.core.domain.HandicapGroup domainHandicapGroup = DomainEntityTestUtils.fullHandicapGroup();
-        org.coner.api.entity.HandicapGroup apiHandicapGroup = ApiEntityTestUtils.fullHandicapGroup();
+        HandicapGroup domainHandicapGroup = DomainEntityTestUtils.fullHandicapGroup();
+        HandicapGroupApiEntity handicapGroupApiEntity = ApiEntityTestUtils.fullHandicapGroup();
 
         // sanity check test
         assertThat(domainHandicapGroup.getId()).isSameAs(TestConstants.HANDICAP_GROUP_ID);
-        assertThat(apiHandicapGroup.getId()).isSameAs(TestConstants.HANDICAP_GROUP_ID);
+        assertThat(handicapGroupApiEntity.getId()).isSameAs(TestConstants.HANDICAP_GROUP_ID);
 
         when(conerCoreService.getHandicapGroup(TestConstants.HANDICAP_GROUP_ID)).thenReturn(domainHandicapGroup);
-        when(handicapGroupBoundary.toApiEntity(domainHandicapGroup)).thenReturn(apiHandicapGroup);
+        when(handicapGroupBoundary.toApiEntity(domainHandicapGroup)).thenReturn(handicapGroupApiEntity);
 
-        Response handicapGroupResponseContainer = resources.client()
+        Response responseContainer = resources.client()
                 .target("/handicapGroups/" + TestConstants.HANDICAP_GROUP_ID)
                 .request(MediaType.APPLICATION_JSON_TYPE)
                 .get();
@@ -56,13 +57,13 @@ public class HandicapGroupResourceTest {
         verify(handicapGroupBoundary).toApiEntity(domainHandicapGroup);
         verifyNoMoreInteractions(conerCoreService, handicapGroupBoundary);
 
-        assertThat(handicapGroupResponseContainer).isNotNull();
-        assertThat(handicapGroupResponseContainer.getStatus()).isEqualTo(HttpStatus.OK_200);
+        assertThat(responseContainer).isNotNull();
+        assertThat(responseContainer.getStatus()).isEqualTo(HttpStatus.OK_200);
 
-        HandicapGroup getHandicapGroupResponse = handicapGroupResponseContainer.readEntity(HandicapGroup.class);
+        HandicapGroupApiEntity getHandicapGroupResponse = responseContainer.readEntity(HandicapGroupApiEntity.class);
         assertThat(getHandicapGroupResponse)
                 .isNotNull()
-                .isEqualTo(apiHandicapGroup);
+                .isEqualTo(handicapGroupApiEntity);
     }
 
     @Test

--- a/dropwizard-app/src/test/java/org/coner/resource/HandicapGroupsResourceTest.java
+++ b/dropwizard-app/src/test/java/org/coner/resource/HandicapGroupsResourceTest.java
@@ -1,5 +1,6 @@
 package org.coner.resource;
 
+import org.coner.api.entity.HandicapGroupApiEntity;
 import org.coner.api.response.*;
 import org.coner.boundary.HandicapGroupBoundary;
 import org.coner.core.ConerCoreService;
@@ -58,11 +59,11 @@ public class HandicapGroupsResourceTest {
 
     @Test
     public void whenAddHandicapGroupWithUserSuppliedIdItShouldFailValidation() throws Exception {
-        org.coner.api.entity.HandicapGroup requestHandicapGroup = objectMapper.readValue(
+        HandicapGroupApiEntity requestHandicapGroup = objectMapper.readValue(
                 FixtureHelpers.fixture("fixtures/api/entity/handicap_group_add-request-with-id.json"),
-                org.coner.api.entity.HandicapGroup.class
+                HandicapGroupApiEntity.class
         );
-        Entity<org.coner.api.entity.HandicapGroup> requestEntity = Entity.json(requestHandicapGroup);
+        Entity<HandicapGroupApiEntity> requestEntity = Entity.json(requestHandicapGroup);
 
         Response response = resources.client()
                 .target("/handicapGroups")
@@ -79,11 +80,11 @@ public class HandicapGroupsResourceTest {
 
     @Test
     public void whenAddHandicapGroupWithLargeFactorItShouldFailValidation() throws Exception {
-        org.coner.api.entity.HandicapGroup requestHandicapGroup = objectMapper.readValue(
+        HandicapGroupApiEntity requestHandicapGroup = objectMapper.readValue(
                 FixtureHelpers.fixture("fixtures/api/entity/handicap_group_add-request-wrong-factor.json"),
-                org.coner.api.entity.HandicapGroup.class
+                HandicapGroupApiEntity.class
         );
-        Entity<org.coner.api.entity.HandicapGroup> requestEntity = Entity.json(requestHandicapGroup);
+        Entity<HandicapGroupApiEntity> requestEntity = Entity.json(requestHandicapGroup);
 
 
         Response response = resources.client()
@@ -125,13 +126,13 @@ public class HandicapGroupsResourceTest {
 
         List<HandicapGroup> domainHandicapGroups = new ArrayList<>();
         domainHandicapGroups.add(DomainEntityTestUtils.fullHandicapGroup());
-        List<org.coner.api.entity.HandicapGroup> apiHandicapGroups = new ArrayList<>();
-        apiHandicapGroups.add(ApiEntityTestUtils.fullHandicapGroup());
+        List<HandicapGroupApiEntity> handicapGroupApiEntities = new ArrayList<>();
+        handicapGroupApiEntities.add(ApiEntityTestUtils.fullHandicapGroup());
 
         when(conerCoreService.getHandicapGroups())
                 .thenReturn(domainHandicapGroups);
         when(handicapGroupBoundary.toApiEntities(domainHandicapGroups))
-                .thenReturn(apiHandicapGroups);
+                .thenReturn(handicapGroupApiEntities);
 
         GetHandicapGroupsResponse response = resources.client()
                 .target("/handicapGroups")
@@ -152,14 +153,14 @@ public class HandicapGroupsResourceTest {
 
 
     private Response postHandicapGroup() throws Exception {
-        org.coner.api.entity.HandicapGroup requestHandicapGroup = objectMapper.readValue(
+        HandicapGroupApiEntity requestHandicapGroup = objectMapper.readValue(
                 FixtureHelpers.fixture("fixtures/api/entity/handicap_group_add-request.json"),
-                org.coner.api.entity.HandicapGroup.class
+                HandicapGroupApiEntity.class
         );
 
-        Entity<org.coner.api.entity.HandicapGroup> requestEntity = Entity.json(requestHandicapGroup);
+        Entity<HandicapGroupApiEntity> requestEntity = Entity.json(requestHandicapGroup);
 
-        org.coner.core.domain.HandicapGroup requestHandicapGroupAsDomain = DomainEntityTestUtils.fullHandicapGroup();
+        HandicapGroup requestHandicapGroupAsDomain = DomainEntityTestUtils.fullHandicapGroup();
 
         when(handicapGroupBoundary.toDomainEntity(requestHandicapGroup)).thenReturn(requestHandicapGroupAsDomain);
 

--- a/dropwizard-app/src/test/java/org/coner/util/ApiEntityTestUtils.java
+++ b/dropwizard-app/src/test/java/org/coner/util/ApiEntityTestUtils.java
@@ -24,18 +24,18 @@ public final class ApiEntityTestUtils {
         return apiEvent;
     }
 
-    public static Registration fullApiRegistration() {
+    public static RegistrationApiEntity fullApiRegistration() {
         return fullApiRegistration(TestConstants.REGISTRATION_ID, TestConstants.REGISTRATION_FIRSTNAME,
                 TestConstants.REGISTRATION_LASTNAME);
     }
 
-    public static Registration fullApiRegistration(String registrationId, String registrationFirstName,
+    public static RegistrationApiEntity fullApiRegistration(String registrationId, String registrationFirstName,
                                                    String registrationLastName) {
-        Registration apiRegistration = new Registration();
-        apiRegistration.setId(registrationId);
-        apiRegistration.setFirstName(registrationFirstName);
-        apiRegistration.setLastName(registrationLastName);
-        return apiRegistration;
+        RegistrationApiEntity registration = new RegistrationApiEntity();
+        registration.setId(registrationId);
+        registration.setFirstName(registrationFirstName);
+        registration.setLastName(registrationLastName);
+        return registration;
     }
 
     public static HandicapGroupApiEntity fullHandicapGroup() {

--- a/dropwizard-app/src/test/java/org/coner/util/ApiEntityTestUtils.java
+++ b/dropwizard-app/src/test/java/org/coner/util/ApiEntityTestUtils.java
@@ -133,19 +133,19 @@ public final class ApiEntityTestUtils {
         return competitionGroup;
     }
 
-    public static CompetitionGroupSet fullCompetitionGroupSet(
+    public static CompetitionGroupSetApiEntity fullCompetitionGroupSet(
             String competitionGroupSetId,
             String competitionGroupSetName,
             Set<CompetitionGroupApiEntity> competitionGroupApiEntities
     ) {
-        CompetitionGroupSet competitionGroupSet = new CompetitionGroupSet();
+        CompetitionGroupSetApiEntity competitionGroupSet = new CompetitionGroupSetApiEntity();
         competitionGroupSet.setId(competitionGroupSetId);
         competitionGroupSet.setName(competitionGroupSetName);
         competitionGroupSet.setCompetitionGroups(competitionGroupApiEntities);
         return competitionGroupSet;
     }
 
-    public static CompetitionGroupSet fullCompetitionGroupSet() {
+    public static CompetitionGroupSetApiEntity fullCompetitionGroupSet() {
         return fullCompetitionGroupSet(
                 TestConstants.COMPETITION_GROUP_SET_ID,
                 TestConstants.COMPETITION_GROUP_SET_NAME,

--- a/dropwizard-app/src/test/java/org/coner/util/ApiEntityTestUtils.java
+++ b/dropwizard-app/src/test/java/org/coner/util/ApiEntityTestUtils.java
@@ -56,19 +56,19 @@ public final class ApiEntityTestUtils {
         return handicapGroup;
     }
 
-    public static HandicapGroupSet fullHandicapGroupSet(
+    public static HandicapGroupSetApiEntity fullHandicapGroupSet(
             String handicapGroupSetId,
             String handicapGroupSetName,
             Set<HandicapGroupApiEntity> handicapGroups
     ) {
-        HandicapGroupSet handicapGroupSet = new HandicapGroupSet();
+        HandicapGroupSetApiEntity handicapGroupSet = new HandicapGroupSetApiEntity();
         handicapGroupSet.setId(handicapGroupSetId);
         handicapGroupSet.setName(handicapGroupSetName);
         handicapGroupSet.setHandicapGroups(handicapGroups);
         return handicapGroupSet;
     }
 
-    public static HandicapGroupSet fullHandicapGroupSet() {
+    public static HandicapGroupSetApiEntity fullHandicapGroupSet() {
         return fullHandicapGroupSet(
                 TestConstants.HANDICAP_GROUP_SET_ID,
                 TestConstants.HANDICAP_GROUP_SET_NAME,

--- a/dropwizard-app/src/test/java/org/coner/util/ApiEntityTestUtils.java
+++ b/dropwizard-app/src/test/java/org/coner/util/ApiEntityTestUtils.java
@@ -38,28 +38,28 @@ public final class ApiEntityTestUtils {
         return apiRegistration;
     }
 
-    public static HandicapGroup fullHandicapGroup() {
+    public static HandicapGroupApiEntity fullHandicapGroup() {
         return fullHandicapGroup(
                 TestConstants.HANDICAP_GROUP_ID,
                 TestConstants.HANDICAP_GROUP_NAME,
                 TestConstants.HANDICAP_GROUP_FACTOR);
     }
 
-    public static HandicapGroup fullHandicapGroup(
+    public static HandicapGroupApiEntity fullHandicapGroup(
             String handicapGroupId,
             String handicapGroupName,
             BigDecimal handicapGroupFactor) {
-        HandicapGroup apiHandicapGroup = new HandicapGroup();
-        apiHandicapGroup.setId(handicapGroupId);
-        apiHandicapGroup.setName(handicapGroupName);
-        apiHandicapGroup.setHandicapFactor(handicapGroupFactor);
-        return apiHandicapGroup;
+        HandicapGroupApiEntity handicapGroup = new HandicapGroupApiEntity();
+        handicapGroup.setId(handicapGroupId);
+        handicapGroup.setName(handicapGroupName);
+        handicapGroup.setHandicapFactor(handicapGroupFactor);
+        return handicapGroup;
     }
 
     public static HandicapGroupSet fullHandicapGroupSet(
             String handicapGroupSetId,
             String handicapGroupSetName,
-            Set<HandicapGroup> handicapGroups
+            Set<HandicapGroupApiEntity> handicapGroups
     ) {
         HandicapGroupSet handicapGroupSet = new HandicapGroupSet();
         handicapGroupSet.setId(handicapGroupSetId);

--- a/dropwizard-app/src/test/java/org/coner/util/ApiEntityTestUtils.java
+++ b/dropwizard-app/src/test/java/org/coner/util/ApiEntityTestUtils.java
@@ -12,16 +12,16 @@ public final class ApiEntityTestUtils {
     private ApiEntityTestUtils() {
     }
 
-    public static Event fullApiEvent() {
+    public static EventApiEntity fullApiEvent() {
         return fullApiEvent(TestConstants.EVENT_ID, TestConstants.EVENT_NAME, TestConstants.EVENT_DATE);
     }
 
-    public static Event fullApiEvent(String eventId, String eventName, Date eventDate) {
-        Event apiEvent = new Event();
-        apiEvent.setId(eventId);
-        apiEvent.setName(eventName);
-        apiEvent.setDate(eventDate);
-        return apiEvent;
+    public static EventApiEntity fullApiEvent(String eventId, String eventName, Date eventDate) {
+        EventApiEntity event = new EventApiEntity();
+        event.setId(eventId);
+        event.setName(eventName);
+        event.setDate(eventDate);
+        return event;
     }
 
     public static RegistrationApiEntity fullApiRegistration() {

--- a/dropwizard-app/src/test/java/org/coner/util/ApiEntityTestUtils.java
+++ b/dropwizard-app/src/test/java/org/coner/util/ApiEntityTestUtils.java
@@ -107,7 +107,7 @@ public final class ApiEntityTestUtils {
         );
     }
 
-    public static CompetitionGroup fullCompetitionGroup() {
+    public static CompetitionGroupApiEntity fullCompetitionGroup() {
         return fullCompetitionGroup(
                 TestConstants.COMPETITION_GROUP_ID,
                 TestConstants.COMPETITION_GROUP_NAME,
@@ -117,31 +117,31 @@ public final class ApiEntityTestUtils {
         );
     }
 
-    public static CompetitionGroup fullCompetitionGroup(
+    public static CompetitionGroupApiEntity fullCompetitionGroup(
             String competitionGroupId,
             String competitionGroupName,
             BigDecimal competitionGroupHandicapFactor,
             String competitionGroupResultTimeType,
             boolean competitionGroupGrouping
     ) {
-        CompetitionGroup apiCompetitionGroup = new CompetitionGroup();
-        apiCompetitionGroup.setId(competitionGroupId);
-        apiCompetitionGroup.setName(competitionGroupName);
-        apiCompetitionGroup.setHandicapFactor(competitionGroupHandicapFactor);
-        apiCompetitionGroup.setResultTimeType(competitionGroupResultTimeType);
-        apiCompetitionGroup.setGrouping(competitionGroupGrouping);
-        return apiCompetitionGroup;
+        CompetitionGroupApiEntity competitionGroup = new CompetitionGroupApiEntity();
+        competitionGroup.setId(competitionGroupId);
+        competitionGroup.setName(competitionGroupName);
+        competitionGroup.setHandicapFactor(competitionGroupHandicapFactor);
+        competitionGroup.setResultTimeType(competitionGroupResultTimeType);
+        competitionGroup.setGrouping(competitionGroupGrouping);
+        return competitionGroup;
     }
 
     public static CompetitionGroupSet fullCompetitionGroupSet(
             String competitionGroupSetId,
             String competitionGroupSetName,
-            Set<CompetitionGroup> competitionGroups
+            Set<CompetitionGroupApiEntity> competitionGroupApiEntities
     ) {
         CompetitionGroupSet competitionGroupSet = new CompetitionGroupSet();
         competitionGroupSet.setId(competitionGroupSetId);
         competitionGroupSet.setName(competitionGroupSetName);
-        competitionGroupSet.setCompetitionGroups(competitionGroups);
+        competitionGroupSet.setCompetitionGroups(competitionGroupApiEntities);
         return competitionGroupSet;
     }
 

--- a/dropwizard-app/src/test/java/org/coner/util/HibernateEntityUtils.java
+++ b/dropwizard-app/src/test/java/org/coner/util/HibernateEntityUtils.java
@@ -1,6 +1,6 @@
 package org.coner.util;
 
-import org.coner.hibernate.entity.Event;
+import org.coner.hibernate.entity.EventHibernateEntity;
 
 import java.util.Date;
 
@@ -12,15 +12,15 @@ public final class HibernateEntityUtils {
     private HibernateEntityUtils() {
     }
 
-    public static Event fullHibernateEvent() {
+    public static EventHibernateEntity fullHibernateEvent() {
         return fullHibernateEvent(TestConstants.EVENT_ID, TestConstants.EVENT_NAME, TestConstants.EVENT_DATE);
     }
 
-    public static Event fullHibernateEvent(String eventId, String eventName, Date eventDate) {
-        Event hibernateEvent = new Event();
-        hibernateEvent.setId(eventId);
-        hibernateEvent.setName(eventName);
-        hibernateEvent.setDate(eventDate);
-        return hibernateEvent;
+    public static EventHibernateEntity fullHibernateEvent(String eventId, String eventName, Date eventDate) {
+        EventHibernateEntity event = new EventHibernateEntity();
+        event.setId(eventId);
+        event.setName(eventName);
+        event.setDate(eventDate);
+        return event;
     }
 }


### PR DESCRIPTION
The code around boundaries which was referencing the entity on the other side by a fully qualified class name was getting very clunky. In many cases it wasn't possible to complete a statement without one or more line wraps in the statement.

The new pattern is:

- API entities renamed to *ApiEntity
- Domain entities not renamed
- Hibernate entities renamed to *HibernateEntity

This pull request will be ongoing until all entity classes are renamed.