### PR TITLE
Reduce repetitive code in Gateway classes

### DIFF
--- a/dropwizard-app/src/main/java/org/coner/ConerDropwizardApplication.java
+++ b/dropwizard-app/src/main/java/org/coner/ConerDropwizardApplication.java
@@ -214,8 +214,8 @@ public class ConerDropwizardApplication extends Application<ConerDropwizardConfi
         if (registrationGateway == null) {
             registrationGateway = new RegistrationGateway(
                     getRegistrationBoundary(),
-                    getEventBoundary(),
-                    getRegistrationDao()
+                    getRegistrationDao(),
+                    getEventBoundary()
             );
         }
         return registrationGateway;
@@ -367,7 +367,7 @@ public class ConerDropwizardApplication extends Application<ConerDropwizardConfi
     }
 
 
-   private ConerCoreService getConerCoreService() {
+    private ConerCoreService getConerCoreService() {
         if (conerCoreService == null) {
             conerCoreService = new ConerCoreService(
                     getEventGateway(),

--- a/dropwizard-app/src/main/java/org/coner/core/gateway/AbstractGateway.java
+++ b/dropwizard-app/src/main/java/org/coner/core/gateway/AbstractGateway.java
@@ -1,0 +1,50 @@
+package org.coner.core.gateway;
+
+import org.coner.boundary.AbstractBoundary;
+import org.coner.core.domain.DomainEntity;
+import org.coner.hibernate.dao.HibernateEntityDao;
+import org.coner.hibernate.entity.HibernateEntity;
+
+import com.google.common.base.*;
+import java.util.List;
+
+public abstract class AbstractGateway<
+        DE extends DomainEntity,
+        HE extends HibernateEntity,
+        B extends AbstractBoundary<?, DE, HE>,
+        D extends HibernateEntityDao<HE>> {
+
+    private final B boundary;
+    private final D dao;
+
+    protected AbstractGateway(B boundary, D dao) {
+        this.boundary = boundary;
+        this.dao = dao;
+    }
+
+    public void create(DE domainEntity) {
+        Preconditions.checkNotNull(domainEntity);
+        HE hibernateEntity = boundary.toHibernateEntity(domainEntity);
+        dao.create(hibernateEntity);
+        boundary.merge(hibernateEntity, domainEntity);
+    }
+
+    public List<DE> getAll() {
+        List<HE> hibernateEntities = dao.findAll();
+        return boundary.toDomainEntities(hibernateEntities);
+    }
+
+    public DE findById(String id) {
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(id), "id must not be null or empty");
+        HE hibernateEntity = dao.findById(id);
+        return boundary.toDomainEntity(hibernateEntity);
+    }
+
+    protected B getBoundary() {
+        return boundary;
+    }
+
+    protected D getDao() {
+        return dao;
+    }
+}

--- a/dropwizard-app/src/main/java/org/coner/core/gateway/CompetitionGroupGateway.java
+++ b/dropwizard-app/src/main/java/org/coner/core/gateway/CompetitionGroupGateway.java
@@ -5,41 +5,13 @@ import org.coner.core.domain.CompetitionGroup;
 import org.coner.hibernate.dao.CompetitionGroupDao;
 import org.coner.hibernate.entity.CompetitionGroupHibernateEntity;
 
-import com.google.common.base.*;
-import java.util.List;
+public class CompetitionGroupGateway extends AbstractGateway<
+        CompetitionGroup,
+        CompetitionGroupHibernateEntity,
+        CompetitionGroupBoundary,
+        CompetitionGroupDao> {
 
-public class CompetitionGroupGateway {
-
-    private final CompetitionGroupBoundary competitionGroupBoundary;
-    private final CompetitionGroupDao competitionGroupDao;
-
-    public CompetitionGroupGateway(
-            CompetitionGroupBoundary competitionGroupBoundary,
-            CompetitionGroupDao competitionGroupDao
-    ) {
-        this.competitionGroupBoundary = competitionGroupBoundary;
-        this.competitionGroupDao = competitionGroupDao;
-    }
-
-    public void create(CompetitionGroup competitionGroup) {
-        Preconditions.checkNotNull(competitionGroup);
-        CompetitionGroupHibernateEntity competitionGroupHibernateEntity = competitionGroupBoundary.toHibernateEntity(
-                competitionGroup
-        );
-        competitionGroupDao.createOrUpdate(competitionGroupHibernateEntity);
-        competitionGroupBoundary.merge(competitionGroupHibernateEntity, competitionGroup);
-    }
-
-    public List<CompetitionGroup> getAll() {
-        List<CompetitionGroupHibernateEntity> competitionGroupHibernateEntities = competitionGroupDao.findAll();
-        return competitionGroupBoundary.toDomainEntities(competitionGroupHibernateEntities);
-    }
-
-    public CompetitionGroup findById(String competitionGroupId) {
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(competitionGroupId));
-        CompetitionGroupHibernateEntity competitionGroupHibernateEntity = competitionGroupDao.findById(
-                competitionGroupId
-        );
-        return competitionGroupBoundary.toDomainEntity(competitionGroupHibernateEntity);
+    public CompetitionGroupGateway(CompetitionGroupBoundary boundary, CompetitionGroupDao dao) {
+        super(boundary, dao);
     }
 }

--- a/dropwizard-app/src/main/java/org/coner/core/gateway/CompetitionGroupSetGateway.java
+++ b/dropwizard-app/src/main/java/org/coner/core/gateway/CompetitionGroupSetGateway.java
@@ -5,26 +5,13 @@ import org.coner.core.domain.CompetitionGroupSet;
 import org.coner.hibernate.dao.CompetitionGroupSetDao;
 import org.coner.hibernate.entity.CompetitionGroupSetHibernateEntity;
 
-import com.google.common.base.Preconditions;
+public class CompetitionGroupSetGateway extends AbstractGateway<
+        CompetitionGroupSet,
+        CompetitionGroupSetHibernateEntity,
+        CompetitionGroupSetBoundary,
+        CompetitionGroupSetDao> {
 
-public class CompetitionGroupSetGateway {
-
-    private final CompetitionGroupSetBoundary competitionGroupSetBoundary;
-    private final CompetitionGroupSetDao competitionGroupSetDao;
-
-    public CompetitionGroupSetGateway(
-            CompetitionGroupSetBoundary competitionGroupSetBoundary,
-            CompetitionGroupSetDao competitionGroupSetDao
-    ) {
-        this.competitionGroupSetBoundary = competitionGroupSetBoundary;
-        this.competitionGroupSetDao = competitionGroupSetDao;
-    }
-
-    public void create(CompetitionGroupSet competitionGroupSet) {
-        Preconditions.checkNotNull(competitionGroupSet);
-        CompetitionGroupSetHibernateEntity competitionGroupSetHibernateEntity = competitionGroupSetBoundary
-                .toHibernateEntity(competitionGroupSet);
-        competitionGroupSetDao.createOrUpdate(competitionGroupSetHibernateEntity);
-        competitionGroupSetBoundary.merge(competitionGroupSetHibernateEntity, competitionGroupSet);
+    public CompetitionGroupSetGateway(CompetitionGroupSetBoundary boundary, CompetitionGroupSetDao dao) {
+        super(boundary, dao);
     }
 }

--- a/dropwizard-app/src/main/java/org/coner/core/gateway/EventGateway.java
+++ b/dropwizard-app/src/main/java/org/coner/core/gateway/EventGateway.java
@@ -5,34 +5,13 @@ import org.coner.core.domain.Event;
 import org.coner.hibernate.dao.EventDao;
 import org.coner.hibernate.entity.EventHibernateEntity;
 
-import com.google.common.base.*;
-import java.util.List;
+public class EventGateway extends AbstractGateway<
+        Event,
+        EventHibernateEntity,
+        EventBoundary,
+        EventDao> {
 
-public class EventGateway {
-
-    private final EventBoundary eventBoundary;
-    private final EventDao eventDao;
-
-    public EventGateway(EventBoundary eventBoundary, EventDao eventDao) {
-        this.eventBoundary = eventBoundary;
-        this.eventDao = eventDao;
-    }
-
-    public List<Event> getAll() {
-        List<EventHibernateEntity> events = eventDao.findAll();
-        return eventBoundary.toDomainEntities(events);
-    }
-
-    public Event findById(String eventId) {
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(eventId));
-        EventHibernateEntity hibernateEvent = eventDao.findById(eventId);
-        return eventBoundary.toDomainEntity(hibernateEvent);
-    }
-
-    public void create(Event event) {
-        Preconditions.checkNotNull(event);
-        EventHibernateEntity hibernateEvent = eventBoundary.toHibernateEntity(event);
-        eventDao.create(hibernateEvent);
-        eventBoundary.merge(hibernateEvent, event);
+    public EventGateway(EventBoundary boundary, EventDao dao) {
+        super(boundary, dao);
     }
 }

--- a/dropwizard-app/src/main/java/org/coner/core/gateway/HandicapGroupGateway.java
+++ b/dropwizard-app/src/main/java/org/coner/core/gateway/HandicapGroupGateway.java
@@ -5,35 +5,13 @@ import org.coner.core.domain.HandicapGroup;
 import org.coner.hibernate.dao.HandicapGroupDao;
 import org.coner.hibernate.entity.HandicapGroupHibernateEntity;
 
-import com.google.common.base.*;
-import java.util.List;
+public class HandicapGroupGateway extends AbstractGateway<
+        HandicapGroup,
+        HandicapGroupHibernateEntity,
+        HandicapGroupBoundary,
+        HandicapGroupDao> {
 
-public class HandicapGroupGateway {
-
-    private final HandicapGroupBoundary handicapGroupBoundary;
-    private final HandicapGroupDao handicapGroupDao;
-
-    public HandicapGroupGateway(HandicapGroupBoundary handicapGroupBoundary, HandicapGroupDao handicapGroupDao) {
-        this.handicapGroupBoundary = handicapGroupBoundary;
-        this.handicapGroupDao = handicapGroupDao;
-    }
-
-    public void create(HandicapGroup handicapGroup) {
-        Preconditions.checkNotNull(handicapGroup);
-        HandicapGroupHibernateEntity hibernateHandicapGroup =
-                handicapGroupBoundary.toHibernateEntity(handicapGroup);
-        handicapGroupDao.create(hibernateHandicapGroup);
-        handicapGroupBoundary.merge(hibernateHandicapGroup, handicapGroup);
-    }
-
-    public List<HandicapGroup> getAll() {
-        List<HandicapGroupHibernateEntity> handicapGroups = handicapGroupDao.findAll();
-        return handicapGroupBoundary.toDomainEntities(handicapGroups);
-    }
-
-    public HandicapGroup findById(String handicapGroupId) {
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(handicapGroupId));
-        HandicapGroupHibernateEntity hibernateHandicapGroup = handicapGroupDao.findById(handicapGroupId);
-        return handicapGroupBoundary.toDomainEntity(hibernateHandicapGroup);
+    public HandicapGroupGateway(HandicapGroupBoundary boundary, HandicapGroupDao dao) {
+        super(boundary, dao);
     }
 }

--- a/dropwizard-app/src/main/java/org/coner/core/gateway/HandicapGroupSetGateway.java
+++ b/dropwizard-app/src/main/java/org/coner/core/gateway/HandicapGroupSetGateway.java
@@ -5,26 +5,13 @@ import org.coner.core.domain.HandicapGroupSet;
 import org.coner.hibernate.dao.HandicapGroupSetDao;
 import org.coner.hibernate.entity.HandicapGroupSetHibernateEntity;
 
-import com.google.common.base.Preconditions;
+public class HandicapGroupSetGateway extends AbstractGateway<
+        HandicapGroupSet,
+        HandicapGroupSetHibernateEntity,
+        HandicapGroupSetBoundary,
+        HandicapGroupSetDao> {
 
-public class HandicapGroupSetGateway {
-
-    private final HandicapGroupSetBoundary handicapGroupSetBoundary;
-    private final HandicapGroupSetDao handicapGroupSetDao;
-
-    public HandicapGroupSetGateway(
-            HandicapGroupSetBoundary handicapGroupSetBoundary,
-            HandicapGroupSetDao handicapGroupSetDao
-    ) {
-        this.handicapGroupSetBoundary = handicapGroupSetBoundary;
-        this.handicapGroupSetDao = handicapGroupSetDao;
-    }
-
-    public void create(HandicapGroupSet handicapGroupSet) {
-        Preconditions.checkNotNull(handicapGroupSet);
-        HandicapGroupSetHibernateEntity handicapGroupSetHibernateEntity = handicapGroupSetBoundary
-                .toHibernateEntity(handicapGroupSet);
-        handicapGroupSetDao.createOrUpdate(handicapGroupSetHibernateEntity);
-        handicapGroupSetBoundary.merge(handicapGroupSetHibernateEntity, handicapGroupSet);
+    public HandicapGroupSetGateway(HandicapGroupSetBoundary boundary, HandicapGroupSetDao dao) {
+        super(boundary, dao);
     }
 }

--- a/dropwizard-app/src/main/java/org/coner/core/gateway/RegistrationGateway.java
+++ b/dropwizard-app/src/main/java/org/coner/core/gateway/RegistrationGateway.java
@@ -5,43 +5,27 @@ import org.coner.core.domain.*;
 import org.coner.hibernate.dao.RegistrationDao;
 import org.coner.hibernate.entity.*;
 
-import com.google.common.base.*;
+import com.google.common.base.Preconditions;
 import java.util.List;
 
-public class RegistrationGateway {
+public class RegistrationGateway extends AbstractGateway<
+        Registration,
+        RegistrationHibernateEntity,
+        RegistrationBoundary,
+        RegistrationDao> {
 
-    private final RegistrationBoundary registrationBoundary;
     private final EventBoundary eventBoundary;
-    private final RegistrationDao registrationDao;
 
-    public RegistrationGateway(
-            RegistrationBoundary registrationBoundary,
-            EventBoundary eventBoundary,
-            RegistrationDao registrationDao) {
-        this.registrationBoundary = registrationBoundary;
+    public RegistrationGateway(RegistrationBoundary boundary, RegistrationDao dao, EventBoundary eventBoundary) {
+        super(boundary, dao);
         this.eventBoundary = eventBoundary;
-        this.registrationDao = registrationDao;
-    }
-
-    public Registration findById(String registrationId) {
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(registrationId));
-        RegistrationHibernateEntity hibernateRegistration = registrationDao.findById(registrationId);
-        return registrationBoundary.toDomainEntity(hibernateRegistration);
     }
 
     public List<Registration> getAllWith(Event event) {
         Preconditions.checkNotNull(event);
         EventHibernateEntity hibernateEvent = eventBoundary.toHibernateEntity(event);
-        List<RegistrationHibernateEntity> registrations = registrationDao.getAllWith(hibernateEvent);
-        return registrationBoundary.toDomainEntities(registrations);
-    }
-
-    public void create(Registration registration) {
-        Preconditions.checkNotNull(registration);
-        RegistrationHibernateEntity hibernateRegistration =
-                registrationBoundary.toHibernateEntity(registration);
-        registrationDao.create(hibernateRegistration);
-        registrationBoundary.merge(hibernateRegistration, registration);
+        List<RegistrationHibernateEntity> registrations = getDao().getAllWith(hibernateEvent);
+        return getBoundary().toDomainEntities(registrations);
     }
 
 }

--- a/dropwizard-app/src/main/java/org/coner/hibernate/dao/CompetitionGroupDao.java
+++ b/dropwizard-app/src/main/java/org/coner/hibernate/dao/CompetitionGroupDao.java
@@ -6,20 +6,25 @@ import io.dropwizard.hibernate.AbstractDAO;
 import java.util.List;
 import org.hibernate.SessionFactory;
 
-public class CompetitionGroupDao extends AbstractDAO<CompetitionGroupHibernateEntity> {
+public class CompetitionGroupDao
+        extends AbstractDAO<CompetitionGroupHibernateEntity>
+        implements HibernateEntityDao<CompetitionGroupHibernateEntity> {
 
     public CompetitionGroupDao(SessionFactory sessionFactory) {
         super(sessionFactory);
     }
 
-    public void createOrUpdate(CompetitionGroupHibernateEntity competitionGroup) {
+    @Override
+    public void create(CompetitionGroupHibernateEntity competitionGroup) {
         persist(competitionGroup);
     }
 
+    @Override
     public List<CompetitionGroupHibernateEntity> findAll() {
         return list(namedQuery(CompetitionGroupHibernateEntity.QUERY_FIND_ALL));
     }
 
+    @Override
     public CompetitionGroupHibernateEntity findById(String id) {
         return get(id);
     }

--- a/dropwizard-app/src/main/java/org/coner/hibernate/dao/CompetitionGroupSetDao.java
+++ b/dropwizard-app/src/main/java/org/coner/hibernate/dao/CompetitionGroupSetDao.java
@@ -3,15 +3,29 @@ package org.coner.hibernate.dao;
 import org.coner.hibernate.entity.CompetitionGroupSetHibernateEntity;
 
 import io.dropwizard.hibernate.AbstractDAO;
+import java.util.List;
 import org.hibernate.SessionFactory;
 
-public class CompetitionGroupSetDao extends AbstractDAO<CompetitionGroupSetHibernateEntity> {
+public class CompetitionGroupSetDao
+        extends AbstractDAO<CompetitionGroupSetHibernateEntity>
+        implements HibernateEntityDao<CompetitionGroupSetHibernateEntity> {
 
     public CompetitionGroupSetDao(SessionFactory sessionFactory) {
         super(sessionFactory);
     }
 
-    public void createOrUpdate(CompetitionGroupSetHibernateEntity competitionGroupSet) {
-        persist(competitionGroupSet);
+    @Override
+    public void create(CompetitionGroupSetHibernateEntity entity) {
+        persist(entity);
+    }
+
+    @Override
+    public List<CompetitionGroupSetHibernateEntity> findAll() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public CompetitionGroupSetHibernateEntity findById(String id) {
+        throw new UnsupportedOperationException();
     }
 }

--- a/dropwizard-app/src/main/java/org/coner/hibernate/dao/EventDao.java
+++ b/dropwizard-app/src/main/java/org/coner/hibernate/dao/EventDao.java
@@ -6,21 +6,25 @@ import io.dropwizard.hibernate.AbstractDAO;
 import java.util.List;
 import org.hibernate.SessionFactory;
 
-public class EventDao extends AbstractDAO<EventHibernateEntity> {
-
+public class EventDao
+        extends AbstractDAO<EventHibernateEntity>
+        implements HibernateEntityDao<EventHibernateEntity> {
 
     public EventDao(SessionFactory sessionFactory) {
         super(sessionFactory);
     }
 
+    @Override
     public EventHibernateEntity findById(String id) {
         return get(id);
     }
 
+    @Override
     public List<EventHibernateEntity> findAll() {
         return list(namedQuery(EventHibernateEntity.QUERY_FIND_ALL));
     }
 
+    @Override
     public void create(EventHibernateEntity event) {
         persist(event);
     }

--- a/dropwizard-app/src/main/java/org/coner/hibernate/dao/HandicapGroupDao.java
+++ b/dropwizard-app/src/main/java/org/coner/hibernate/dao/HandicapGroupDao.java
@@ -6,20 +6,25 @@ import io.dropwizard.hibernate.AbstractDAO;
 import java.util.List;
 import org.hibernate.SessionFactory;
 
-public class HandicapGroupDao extends AbstractDAO<HandicapGroupHibernateEntity> {
+public class HandicapGroupDao
+        extends AbstractDAO<HandicapGroupHibernateEntity>
+        implements HibernateEntityDao<HandicapGroupHibernateEntity> {
 
     public HandicapGroupDao(SessionFactory sessionFactory) {
         super(sessionFactory);
     }
 
+    @Override
     public void create(HandicapGroupHibernateEntity handicapGroup) {
         persist(handicapGroup);
     }
 
+    @Override
     public List<HandicapGroupHibernateEntity> findAll() {
         return list(namedQuery(HandicapGroupHibernateEntity.QUERY_FIND_ALL));
     }
 
+    @Override
     public HandicapGroupHibernateEntity findById(String id) {
         return get(id);
     }

--- a/dropwizard-app/src/main/java/org/coner/hibernate/dao/HandicapGroupSetDao.java
+++ b/dropwizard-app/src/main/java/org/coner/hibernate/dao/HandicapGroupSetDao.java
@@ -3,15 +3,29 @@ package org.coner.hibernate.dao;
 import org.coner.hibernate.entity.HandicapGroupSetHibernateEntity;
 
 import io.dropwizard.hibernate.AbstractDAO;
+import java.util.List;
 import org.hibernate.SessionFactory;
 
-public class HandicapGroupSetDao extends AbstractDAO<HandicapGroupSetHibernateEntity> {
+public class HandicapGroupSetDao
+        extends AbstractDAO<HandicapGroupSetHibernateEntity>
+        implements HibernateEntityDao<HandicapGroupSetHibernateEntity> {
 
     public HandicapGroupSetDao(SessionFactory sessionFactory) {
         super(sessionFactory);
     }
 
-    public void createOrUpdate(HandicapGroupSetHibernateEntity handicapGroupSet) {
-        persist(handicapGroupSet);
+    @Override
+    public void create(HandicapGroupSetHibernateEntity entity) {
+        persist(entity);
+    }
+
+    @Override
+    public List<HandicapGroupSetHibernateEntity> findAll() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public HandicapGroupSetHibernateEntity findById(String id) {
+        throw new UnsupportedOperationException();
     }
 }

--- a/dropwizard-app/src/main/java/org/coner/hibernate/dao/HibernateEntityDao.java
+++ b/dropwizard-app/src/main/java/org/coner/hibernate/dao/HibernateEntityDao.java
@@ -1,0 +1,13 @@
+package org.coner.hibernate.dao;
+
+import org.coner.hibernate.entity.HibernateEntity;
+
+import java.util.List;
+
+public interface HibernateEntityDao<HE extends HibernateEntity> {
+    void create(HE entity);
+
+    List<HE> findAll();
+
+    HE findById(String id);
+}

--- a/dropwizard-app/src/main/java/org/coner/hibernate/dao/RegistrationDao.java
+++ b/dropwizard-app/src/main/java/org/coner/hibernate/dao/RegistrationDao.java
@@ -6,12 +6,15 @@ import io.dropwizard.hibernate.AbstractDAO;
 import java.util.List;
 import org.hibernate.*;
 
-public class RegistrationDao extends AbstractDAO<RegistrationHibernateEntity> {
+public class RegistrationDao
+        extends AbstractDAO<RegistrationHibernateEntity>
+        implements HibernateEntityDao<RegistrationHibernateEntity> {
 
     public RegistrationDao(SessionFactory sessionFactory) {
         super(sessionFactory);
     }
 
+    @Override
     public RegistrationHibernateEntity findById(String id) {
         return get(id);
     }
@@ -22,7 +25,13 @@ public class RegistrationDao extends AbstractDAO<RegistrationHibernateEntity> {
         return list(query);
     }
 
+    @Override
     public void create(RegistrationHibernateEntity registration) {
         persist(registration);
+    }
+
+    @Override
+    public List<RegistrationHibernateEntity> findAll() {
+        throw new UnsupportedOperationException();
     }
 }


### PR DESCRIPTION
- Introduce AbstractGateway and HibernateEntityDao
- Automatically handles domain<->hibernate conversions
- Routes getAll(), findById(String), create(Entity) to suitable
HibernateEntityDao interface calls
- Refactor all concrete Gateway/DAO pairs to use AbstractGateway and
HibernateEntityDao