### PR TITLE
Upgrade dropwizard and other dependencies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,21 @@ $ curl http://localhost:8080/events
 {"events":[]}
 $ curl http://localhost:8081/healthcheck
 {"deadlocks":{"healthy":true},"hibernate":{"healthy":true}}
+# Add event
+$ cat src/test/resources/fixtures/api/entity/event_add.json | curl -H "Content-Type: application/json" -X POST -d @- http://localhost:8080/events
+> POST /events HTTP/1.1
+> Host: localhost:8080
+> User-Agent: curl/7.43.0
+> Accept: */*
+> Content-Type: application/json
+> Content-Length: 60
+>
+* upload completely sent off: 60 out of 60 bytes
+< HTTP/1.1 201 Created
+< Date: Thu, 12 Jan 2017 18:43:48 GMT
+< Location: http://localhost:8080/events/3157e6cf-1f8c-4a03-9a97-513759ad17c2
+< Content-Length: 0
+<
 ```
 
 Accessing API (not completed): http://localhost:8080/swagger

--- a/build-tools/src/main/resources/checkstyle/checkstyle.xml
+++ b/build-tools/src/main/resources/checkstyle/checkstyle.xml
@@ -4,23 +4,18 @@
         "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
 
 <module name="Checker">
-    <!--
-         This is a first pass so for the bulk of the checkstyle issues,
-         set them to warnings and only for particularly bad checks, set
-         then to errors
-    -->
-    <property name="severity" value="warning"/>
+    <property name="severity" value="error"/>
 
     <!-- Checks that each Java package has a Javadoc file used for commenting. -->
     <!-- See http://checkstyle.sf.net/config_javadoc.html#JavadocPackage       -->
     <module name="JavadocPackage">
+        <property name="severity" value="warning"/>
         <property name="allowLegacy" value="true"/>
     </module>
 
     <!-- Checks whether files end with a new line.                        -->
     <!-- See http://checkstyle.sf.net/config_misc.html#NewlineAtEndOfFile -->
     <module name="NewlineAtEndOfFile">
-        <property name="severity" value="error"/>
         <property name="lineSeparator" value="lf"/>
     </module>
 
@@ -29,7 +24,6 @@
     <module name="Translation"/>
 
     <module name="FileLength">
-        <property name="severity" value="error"/>
         <property name="max" value="1500"/>
     </module>
 
@@ -37,7 +31,6 @@
     <!-- <module name="RegexpHeader"/>                                -->
 
     <module name="FileTabCharacter">
-        <property name="severity" value="error"/>
         <property name="eachLine" value="true"/>
     </module>
 
@@ -72,15 +65,9 @@
 
         <!-- Checks for imports                              -->
         <!-- See http://checkstyle.sf.net/config_imports.html -->
-        <module name="IllegalImport"> <!-- defaults to sun.* packages -->
-            <property name="severity" value="error"/>
-        </module>
-        <module name="RedundantImport">
-            <property name="severity" value="error"/>
-        </module>
-        <module name="UnusedImports">
-            <property name="severity" value="error"/>
-        </module>
+        <module name="IllegalImport"/> <!-- defaults to sun.* packages -->
+        <module name="RedundantImport"/>
+        <module name="UnusedImports"/>
         <module name="ImportOrder">
             <property name="severity" value="error"/>
             <property name="groups" value="org.coner"/>
@@ -92,15 +79,13 @@
         <!-- Checks for Size Violations.                    -->
         <!-- See http://checkstyle.sf.net/config_sizes.html -->
         <module name="LineLength">
-            <property name="severity" value="error"/>
             <property name="max" value="120"/>
         </module>
         <module name="MethodLength"/>
-        <module name="ParameterNumber"/>
-
-        <module name="TodoComment">
-            <property name="severity" value="error"/>
+        <module name="ParameterNumber">
+            <property name="max" value="10"/>
         </module>
+        <module name="TodoComment"/>
 
         <module name="Regexp">
             <property name="format" value="(debug\().*\+"/>
@@ -114,7 +99,9 @@
         <module name="MethodParamPad"/>
         <module name="NoWhitespaceAfter"/>
         <module name="NoWhitespaceBefore"/>
-        <module name="OperatorWrap"/>
+        <module name="OperatorWrap">
+            <property name="severity" value="warning"/>
+        </module>
         <module name="ParenPad"/>
         <module name="TypecastParenPad"/>
         <module name="WhitespaceAfter"/>
@@ -133,18 +120,20 @@
         <module name="EmptyBlock"/>
         <module name="LeftCurly"/>
         <module name="NeedBraces">
-            <!-- The below property requires checkstyle 6.2 :( -->
-            <property name="allowSingleLineIf" value="true"/>
+            <property name="tokens" value="LITERAL_DO, LITERAL_FOR, LITERAL_WHILE"/>
         </module>
         <module name="RightCurly"/>
 
 
         <!-- Checks for common coding problems               -->
         <!-- See http://checkstyle.sf.net/config_coding.html -->
-        <module name="AvoidInlineConditionals"/>
+        <module name="AvoidInlineConditionals">
+            <property name="severity" value="warning"/>
+        </module>
         <module name="EmptyStatement"/>
         <module name="EqualsHashCode"/>
         <module name="HiddenField">
+            <property name="severity" value="warning"/>
             <property name="ignoreConstructorParameter" value="true"/>
             <property name="ignoreSetter" value="true"/>
         </module>
@@ -152,6 +141,7 @@
         <module name="IllegalInstantiation"/>
         <module name="InnerAssignment"/>
         <module name="MagicNumber">
+            <property name="severity" value="warning"/>
             <property name="ignoreHashCodeMethod" value="true"/>
         </module>
         <module name="MissingSwitchDefault"/>
@@ -163,7 +153,9 @@
         <module name="FinalClass"/>
         <module name="HideUtilityClassConstructor"/>
         <module name="InterfaceIsType"/>
-        <module name="VisibilityModifier"/>
+        <module name="VisibilityModifier">
+            <property name="severity" value="warning"/>
+        </module>
 
 
         <!-- Miscellaneous other checks.                   -->

--- a/dropwizard-api/pom.xml
+++ b/dropwizard-api/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <properties>
-        <dropwizard.version>0.8.1</dropwizard.version>
+        <dropwizard.version>1.0.5</dropwizard.version>
     </properties>
 
     <artifactId>dropwizard-api</artifactId>

--- a/dropwizard-api/src/main/java/org/coner/api/request/AddCompetitionGroupSetRequest.java
+++ b/dropwizard-api/src/main/java/org/coner/api/request/AddCompetitionGroupSetRequest.java
@@ -30,7 +30,7 @@ public class AddCompetitionGroupSetRequest {
     }
 
     /**
-     * Request competition groups be added by Competition Group ID
+     * Request competition groups be added by Competition Group ID.
      */
     public static class CompetitionGroup {
         @NotBlank

--- a/dropwizard-app/pom.xml
+++ b/dropwizard-app/pom.xml
@@ -13,7 +13,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <dropwizard.version>0.8.1</dropwizard.version>
+        <dropwizard.version>1.0.5</dropwizard.version>
     </properties>
 
     <dependencies>
@@ -42,9 +42,30 @@
         </dependency>
 
         <dependency>
+            <groupId>com.smoketurner</groupId>
+            <artifactId>dropwizard-swagger</artifactId>
+            <version>1.0.5-4</version>
+        </dependency>
+
+        <!-- This is needed due to a wonky transitive dependency in the dropwizard-swagger fork above -->
+        <dependency>
+            <groupId>org.glassfish.jersey.containers</groupId>
+            <artifactId>jersey-container-servlet</artifactId>
+            <version>2.23.2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-annotations</artifactId>
+            <version>1.5.12</version>
+        </dependency>
+
+        <!-- Test Dependencies -->
+
+        <dependency>
             <groupId>org.hsqldb</groupId>
             <artifactId>hsqldb</artifactId>
-            <version>2.3.2</version>
+            <version>2.3.4</version>
         </dependency>
 
         <dependency>
@@ -81,13 +102,6 @@
             <version>1.2.3</version>
             <scope>test</scope>
         </dependency>
-
-        <dependency>
-            <groupId>io.federecio</groupId>
-            <artifactId>dropwizard-swagger</artifactId>
-            <version>0.7.0</version>
-        </dependency>
-
     </dependencies>
 
     <build>

--- a/dropwizard-app/src/main/java/org/coner/core/domain/entity/CompetitionGroup.java
+++ b/dropwizard-app/src/main/java/org/coner/core/domain/entity/CompetitionGroup.java
@@ -53,7 +53,7 @@ public class CompetitionGroup extends DomainEntity {
     /**
      * Indicates which result time type should be used to rank results pertaining to a competition group.
      */
-    public static enum ResultTimeType {
+    public enum ResultTimeType {
         HANDICAP,
         RAW
     }

--- a/dropwizard-app/src/main/java/org/coner/resource/CompetitionGroupResource.java
+++ b/dropwizard-app/src/main/java/org/coner/resource/CompetitionGroupResource.java
@@ -7,8 +7,8 @@ import org.coner.core.ConerCoreService;
 import org.coner.core.domain.entity.CompetitionGroup;
 import org.coner.core.exception.EntityNotFoundException;
 
-import com.wordnik.swagger.annotations.*;
 import io.dropwizard.hibernate.UnitOfWork;
+import io.swagger.annotations.*;
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import org.eclipse.jetty.http.HttpStatus;

--- a/dropwizard-app/src/main/java/org/coner/resource/CompetitionGroupSetResource.java
+++ b/dropwizard-app/src/main/java/org/coner/resource/CompetitionGroupSetResource.java
@@ -7,8 +7,8 @@ import org.coner.core.ConerCoreService;
 import org.coner.core.domain.entity.CompetitionGroupSet;
 import org.coner.core.exception.EntityNotFoundException;
 
-import com.wordnik.swagger.annotations.*;
 import io.dropwizard.hibernate.UnitOfWork;
+import io.swagger.annotations.*;
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import org.eclipse.jetty.http.HttpStatus;

--- a/dropwizard-app/src/main/java/org/coner/resource/CompetitionGroupSetsResource.java
+++ b/dropwizard-app/src/main/java/org/coner/resource/CompetitionGroupSetsResource.java
@@ -9,8 +9,8 @@ import org.coner.core.domain.entity.CompetitionGroupSet;
 import org.coner.core.domain.payload.CompetitionGroupSetAddPayload;
 import org.coner.core.exception.EntityNotFoundException;
 
-import com.wordnik.swagger.annotations.*;
 import io.dropwizard.hibernate.UnitOfWork;
+import io.swagger.annotations.*;
 import java.util.List;
 import javax.validation.Valid;
 import javax.ws.rs.*;

--- a/dropwizard-app/src/main/java/org/coner/resource/CompetitionGroupsResource.java
+++ b/dropwizard-app/src/main/java/org/coner/resource/CompetitionGroupsResource.java
@@ -8,8 +8,8 @@ import org.coner.core.ConerCoreService;
 import org.coner.core.domain.entity.CompetitionGroup;
 import org.coner.core.domain.payload.CompetitionGroupAddPayload;
 
-import com.wordnik.swagger.annotations.*;
 import io.dropwizard.hibernate.UnitOfWork;
+import io.swagger.annotations.*;
 import java.util.List;
 import javax.validation.Valid;
 import javax.ws.rs.*;

--- a/dropwizard-app/src/main/java/org/coner/resource/EventRegistrationResource.java
+++ b/dropwizard-app/src/main/java/org/coner/resource/EventRegistrationResource.java
@@ -7,8 +7,8 @@ import org.coner.core.ConerCoreService;
 import org.coner.core.domain.entity.Registration;
 import org.coner.core.exception.*;
 
-import com.wordnik.swagger.annotations.*;
 import io.dropwizard.hibernate.UnitOfWork;
+import io.swagger.annotations.*;
 import javax.ws.rs.*;
 import javax.ws.rs.core.*;
 import org.eclipse.jetty.http.HttpStatus;

--- a/dropwizard-app/src/main/java/org/coner/resource/EventRegistrationsResource.java
+++ b/dropwizard-app/src/main/java/org/coner/resource/EventRegistrationsResource.java
@@ -9,8 +9,8 @@ import org.coner.core.domain.entity.Registration;
 import org.coner.core.domain.payload.RegistrationAddPayload;
 import org.coner.core.exception.EntityNotFoundException;
 
-import com.wordnik.swagger.annotations.*;
 import io.dropwizard.hibernate.UnitOfWork;
+import io.swagger.annotations.*;
 import java.util.List;
 import javax.validation.Valid;
 import javax.ws.rs.*;

--- a/dropwizard-app/src/main/java/org/coner/resource/EventResource.java
+++ b/dropwizard-app/src/main/java/org/coner/resource/EventResource.java
@@ -7,8 +7,8 @@ import org.coner.core.ConerCoreService;
 import org.coner.core.domain.entity.Event;
 import org.coner.core.exception.EntityNotFoundException;
 
-import com.wordnik.swagger.annotations.*;
 import io.dropwizard.hibernate.UnitOfWork;
+import io.swagger.annotations.*;
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import org.eclipse.jetty.http.HttpStatus;

--- a/dropwizard-app/src/main/java/org/coner/resource/EventsResource.java
+++ b/dropwizard-app/src/main/java/org/coner/resource/EventsResource.java
@@ -8,8 +8,8 @@ import org.coner.core.ConerCoreService;
 import org.coner.core.domain.entity.Event;
 import org.coner.core.domain.payload.EventAddPayload;
 
-import com.wordnik.swagger.annotations.*;
 import io.dropwizard.hibernate.UnitOfWork;
+import io.swagger.annotations.*;
 import java.util.List;
 import javax.validation.Valid;
 import javax.ws.rs.*;

--- a/dropwizard-app/src/main/java/org/coner/resource/HandicapGroupResource.java
+++ b/dropwizard-app/src/main/java/org/coner/resource/HandicapGroupResource.java
@@ -7,8 +7,8 @@ import org.coner.core.ConerCoreService;
 import org.coner.core.domain.entity.HandicapGroup;
 import org.coner.core.exception.EntityNotFoundException;
 
-import com.wordnik.swagger.annotations.*;
 import io.dropwizard.hibernate.UnitOfWork;
+import io.swagger.annotations.*;
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import org.eclipse.jetty.http.HttpStatus;

--- a/dropwizard-app/src/main/java/org/coner/resource/HandicapGroupSetsResource.java
+++ b/dropwizard-app/src/main/java/org/coner/resource/HandicapGroupSetsResource.java
@@ -8,8 +8,8 @@ import org.coner.core.ConerCoreService;
 import org.coner.core.domain.entity.HandicapGroupSet;
 import org.coner.core.domain.payload.HandicapGroupSetAddPayload;
 
-import com.wordnik.swagger.annotations.*;
 import io.dropwizard.hibernate.UnitOfWork;
+import io.swagger.annotations.*;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.*;

--- a/dropwizard-app/src/main/java/org/coner/resource/HandicapGroupsResource.java
+++ b/dropwizard-app/src/main/java/org/coner/resource/HandicapGroupsResource.java
@@ -8,8 +8,8 @@ import org.coner.core.ConerCoreService;
 import org.coner.core.domain.entity.HandicapGroup;
 import org.coner.core.domain.payload.HandicapGroupAddPayload;
 
-import com.wordnik.swagger.annotations.*;
 import io.dropwizard.hibernate.UnitOfWork;
+import io.swagger.annotations.*;
 import java.util.List;
 import javax.validation.Valid;
 import javax.ws.rs.*;

--- a/dropwizard-app/src/main/java/org/coner/util/merger/CompositeMerger.java
+++ b/dropwizard-app/src/main/java/org/coner/util/merger/CompositeMerger.java
@@ -3,7 +3,7 @@ package org.coner.util.merger;
 import com.google.common.collect.ImmutableSet;
 
 /**
- * An ObjectMerger which allows composing a chain of ObjectMerger instances
+ * An ObjectMerger which allows composing a chain of ObjectMerger instances.
  *
  * @param <S> the source object type
  * @param <D> the destination object type

--- a/dropwizard-app/src/main/java/org/coner/util/merger/ReflectionPayloadJavaBeanMerger.java
+++ b/dropwizard-app/src/main/java/org/coner/util/merger/ReflectionPayloadJavaBeanMerger.java
@@ -144,7 +144,7 @@ public class ReflectionPayloadJavaBeanMerger<S, D> implements ObjectMerger<S, D>
 
     }
 
-    private static class PayloadToJavaBeanMergeOperation<S, D> extends MergeOperation<S, D> {
+    private static final class PayloadToJavaBeanMergeOperation<S, D> extends MergeOperation<S, D> {
 
         private PayloadToJavaBeanMergeOperation(
                 Field sourcePayloadField,
@@ -166,7 +166,7 @@ public class ReflectionPayloadJavaBeanMerger<S, D> implements ObjectMerger<S, D>
 
     }
 
-    private static class JavaBeanToPayloadMergeOperation<S, D> extends MergeOperation<S, D> {
+    private static final class JavaBeanToPayloadMergeOperation<S, D> extends MergeOperation<S, D> {
 
         private JavaBeanToPayloadMergeOperation(
                 Method sourceJavaBeanAccessor,

--- a/dropwizard-app/src/test/java/org/coner/it/AbstractIntegrationTest.java
+++ b/dropwizard-app/src/test/java/org/coner/it/AbstractIntegrationTest.java
@@ -7,6 +7,10 @@ import javax.ws.rs.client.Client;
 import org.junit.*;
 
 public class AbstractIntegrationTest {
+    protected AbstractIntegrationTest() {
+        // HideUtilityClassConstructor
+    }
+
     @ClassRule
     public static final DropwizardAppRule<ConerDropwizardConfiguration> RULE = IntegrationTestUtils.buildAppRule();
 

--- a/dropwizard-app/src/test/java/org/coner/resource/CompetitionGroupResourceTest.java
+++ b/dropwizard-app/src/test/java/org/coner/resource/CompetitionGroupResourceTest.java
@@ -7,7 +7,6 @@ import org.coner.core.domain.entity.CompetitionGroup;
 import org.coner.core.exception.EntityNotFoundException;
 import org.coner.util.*;
 
-import io.dropwizard.jersey.validation.ConstraintViolationExceptionMapper;
 import io.dropwizard.testing.junit.ResourceTestRule;
 import javax.ws.rs.core.*;
 import org.eclipse.jetty.http.HttpStatus;
@@ -28,7 +27,6 @@ public class CompetitionGroupResourceTest {
     @Rule
     public final ResourceTestRule resources = ResourceTestRule.builder()
             .addResource(new CompetitionGroupResource(boundary, conerCoreService))
-            .addProvider(new ConstraintViolationExceptionMapper())
             .build();
 
     @Before

--- a/dropwizard-app/src/test/java/org/coner/resource/CompetitionGroupSetResourceTest.java
+++ b/dropwizard-app/src/test/java/org/coner/resource/CompetitionGroupSetResourceTest.java
@@ -7,7 +7,6 @@ import org.coner.core.domain.entity.CompetitionGroupSet;
 import org.coner.core.exception.EntityNotFoundException;
 import org.coner.util.*;
 
-import io.dropwizard.jersey.validation.ConstraintViolationExceptionMapper;
 import io.dropwizard.testing.junit.ResourceTestRule;
 import javax.ws.rs.core.*;
 import org.eclipse.jetty.http.HttpStatus;
@@ -33,7 +32,6 @@ public class CompetitionGroupSetResourceTest {
     @Rule
     public final ResourceTestRule resources = ResourceTestRule.builder()
             .addResource(new CompetitionGroupSetResource(conerCoreService, boundary))
-            .addProvider(new ConstraintViolationExceptionMapper())
             .build();
 
     @Before

--- a/dropwizard-app/src/test/java/org/coner/resource/CompetitionGroupSetsResourceTest.java
+++ b/dropwizard-app/src/test/java/org/coner/resource/CompetitionGroupSetsResourceTest.java
@@ -10,7 +10,6 @@ import org.coner.util.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.jackson.Jackson;
-import io.dropwizard.jersey.validation.ConstraintViolationExceptionMapper;
 import io.dropwizard.testing.FixtureHelpers;
 import io.dropwizard.testing.junit.ResourceTestRule;
 import javax.ws.rs.client.Entity;
@@ -45,7 +44,6 @@ public class CompetitionGroupSetsResourceTest {
                     apiDomainBoundary,
                     addPayloadBoundary
             ))
-            .addProvider(new ConstraintViolationExceptionMapper())
             .build();
 
     @Before

--- a/dropwizard-app/src/test/java/org/coner/resource/CompetitionGroupsResourceTest.java
+++ b/dropwizard-app/src/test/java/org/coner/resource/CompetitionGroupsResourceTest.java
@@ -11,7 +11,6 @@ import org.coner.util.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.jackson.Jackson;
-import io.dropwizard.jersey.validation.ConstraintViolationExceptionMapper;
 import io.dropwizard.testing.junit.ResourceTestRule;
 import java.util.*;
 import javax.ws.rs.client.Entity;
@@ -48,7 +47,6 @@ public class CompetitionGroupsResourceTest {
                             apiAddPayloadBoundary
                     )
             )
-            .addProvider(new ConstraintViolationExceptionMapper())
             .build();
     private ObjectMapper objectMapper;
 
@@ -91,7 +89,7 @@ public class CompetitionGroupsResourceTest {
         ErrorsResponse errorsResponse = response.readEntity(ErrorsResponse.class);
         assertThat(errorsResponse.getErrors())
                 .isNotEmpty()
-                .contains("handicapFactor must be less than or equal to 1.000 (was 1.0001)");
+                .contains("handicapFactor must be less than or equal to 1.000");
         verifyZeroInteractions(conerCoreService);
     }
 
@@ -112,7 +110,7 @@ public class CompetitionGroupsResourceTest {
         ErrorsResponse errorsResponse = response.readEntity(ErrorsResponse.class);
         assertThat(errorsResponse.getErrors())
                 .isNotEmpty()
-                .contains("resultTimeType may not be empty (was null)");
+                .contains("resultTimeType may not be empty");
         verifyZeroInteractions(conerCoreService);
     }
 
@@ -133,7 +131,7 @@ public class CompetitionGroupsResourceTest {
         ErrorsResponse errorsResponse = response.readEntity(ErrorsResponse.class);
         assertThat(errorsResponse.getErrors())
                 .isNotEmpty()
-                .contains("grouping may not be null (was null)");
+                .contains("grouping may not be null");
         verifyZeroInteractions(conerCoreService);
     }
 

--- a/dropwizard-app/src/test/java/org/coner/resource/EventRegistrationResourceTest.java
+++ b/dropwizard-app/src/test/java/org/coner/resource/EventRegistrationResourceTest.java
@@ -7,7 +7,6 @@ import org.coner.core.domain.entity.Registration;
 import org.coner.core.exception.*;
 import org.coner.util.*;
 
-import io.dropwizard.jersey.validation.ConstraintViolationExceptionMapper;
 import io.dropwizard.testing.junit.ResourceTestRule;
 import javax.ws.rs.core.*;
 import org.eclipse.jetty.http.HttpStatus;
@@ -31,7 +30,6 @@ public class EventRegistrationResourceTest {
     @Rule
     public final ResourceTestRule resources = ResourceTestRule.builder()
             .addResource(new EventRegistrationResource(registrationBoundary, conerCoreService))
-            .addProvider(new ConstraintViolationExceptionMapper())
             .build();
 
     @Before

--- a/dropwizard-app/src/test/java/org/coner/resource/EventRegistrationsResourceTest.java
+++ b/dropwizard-app/src/test/java/org/coner/resource/EventRegistrationsResourceTest.java
@@ -12,7 +12,6 @@ import org.coner.util.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.jackson.Jackson;
-import io.dropwizard.jersey.validation.ConstraintViolationExceptionMapper;
 import io.dropwizard.testing.FixtureHelpers;
 import io.dropwizard.testing.junit.ResourceTestRule;
 import java.util.*;
@@ -46,7 +45,6 @@ public class EventRegistrationsResourceTest {
                     apiDomainBoundary,
                     addPayloadBoundary
             ))
-            .addProvider(new ConstraintViolationExceptionMapper())
             .build();
 
     @Before

--- a/dropwizard-app/src/test/java/org/coner/resource/EventsResourceTest.java
+++ b/dropwizard-app/src/test/java/org/coner/resource/EventsResourceTest.java
@@ -11,7 +11,6 @@ import org.coner.util.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.jackson.Jackson;
-import io.dropwizard.jersey.validation.ConstraintViolationExceptionMapper;
 import io.dropwizard.testing.FixtureHelpers;
 import io.dropwizard.testing.junit.ResourceTestRule;
 import java.util.*;
@@ -37,7 +36,6 @@ public class EventsResourceTest {
     @Rule
     public final ResourceTestRule resources = ResourceTestRule.builder()
             .addResource(new EventsResource(conerCoreService, apiDomainBoundary, addPayloadBoundary))
-            .addProvider(new ConstraintViolationExceptionMapper())
             .build();
     private ObjectMapper objectMapper;
 
@@ -109,7 +107,7 @@ public class EventsResourceTest {
         assertThat(response.getStatus()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY_422);
         ErrorsResponse errorsResponse = response.readEntity(ErrorsResponse.class);
         assertThat(errorsResponse.getErrors()).isNotEmpty();
-        assertThat(errorsResponse.getErrors()).contains("name may not be empty (was null)");
+        assertThat(errorsResponse.getErrors()).contains("name may not be empty");
         verifyZeroInteractions(conerCoreService);
     }
 
@@ -129,7 +127,7 @@ public class EventsResourceTest {
         assertThat(response.getStatus()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY_422);
         ErrorsResponse errorsResponse = response.readEntity(ErrorsResponse.class);
         assertThat(errorsResponse.getErrors()).isNotEmpty();
-        assertThat(errorsResponse.getErrors()).contains("date may not be null (was null)");
+        assertThat(errorsResponse.getErrors()).contains("date may not be null");
 
         verifyZeroInteractions(conerCoreService);
     }

--- a/dropwizard-app/src/test/java/org/coner/resource/HandicapGroupResourceTest.java
+++ b/dropwizard-app/src/test/java/org/coner/resource/HandicapGroupResourceTest.java
@@ -7,7 +7,6 @@ import org.coner.core.domain.entity.HandicapGroup;
 import org.coner.core.exception.EntityNotFoundException;
 import org.coner.util.*;
 
-import io.dropwizard.jersey.validation.ConstraintViolationExceptionMapper;
 import io.dropwizard.testing.junit.ResourceTestRule;
 import javax.ws.rs.core.*;
 import org.eclipse.jetty.http.HttpStatus;
@@ -31,7 +30,6 @@ public class HandicapGroupResourceTest {
     @Rule
     public final ResourceTestRule resources = ResourceTestRule.builder()
             .addResource(new HandicapGroupResource(handicapGroupBoundary, conerCoreService))
-            .addProvider(new ConstraintViolationExceptionMapper())
             .build();
 
     @Before

--- a/dropwizard-app/src/test/java/org/coner/resource/HandicapGroupSetsResourceTest.java
+++ b/dropwizard-app/src/test/java/org/coner/resource/HandicapGroupSetsResourceTest.java
@@ -10,7 +10,6 @@ import org.coner.util.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.jackson.Jackson;
-import io.dropwizard.jersey.validation.ConstraintViolationExceptionMapper;
 import io.dropwizard.testing.FixtureHelpers;
 import io.dropwizard.testing.junit.ResourceTestRule;
 import javax.ws.rs.client.Entity;
@@ -37,7 +36,6 @@ public class HandicapGroupSetsResourceTest {
     @Rule
     public final ResourceTestRule resources = ResourceTestRule.builder()
             .addResource(new HandicapGroupSetsResource(conerCoreService, domainEntityBoundary, apiAddPayloadBoundary))
-            .addProvider(new ConstraintViolationExceptionMapper())
             .build();
 
     @Before

--- a/dropwizard-app/src/test/java/org/coner/resource/HandicapGroupsResourceTest.java
+++ b/dropwizard-app/src/test/java/org/coner/resource/HandicapGroupsResourceTest.java
@@ -11,7 +11,6 @@ import org.coner.util.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.jackson.Jackson;
-import io.dropwizard.jersey.validation.ConstraintViolationExceptionMapper;
 import io.dropwizard.testing.FixtureHelpers;
 import io.dropwizard.testing.junit.ResourceTestRule;
 import java.util.*;
@@ -41,7 +40,6 @@ public class HandicapGroupsResourceTest {
     @Rule
     public final ResourceTestRule resources = ResourceTestRule.builder()
             .addResource(new HandicapGroupsResource(conerCoreService, apiDomainBoundary, apiAddPayloadBoundary))
-            .addProvider(new ConstraintViolationExceptionMapper())
             .build();
     private ObjectMapper objectMapper;
 
@@ -89,7 +87,7 @@ public class HandicapGroupsResourceTest {
         ErrorsResponse errorsResponse = response.readEntity(ErrorsResponse.class);
         assertThat(errorsResponse.getErrors()).isNotEmpty();
         assertThat(errorsResponse.getErrors())
-                .contains("handicapFactor must be less than or equal to 1.0000 (was 5.00)");
+                .contains("handicapFactor must be less than or equal to 1.0000");
 
         verifyZeroInteractions(conerCoreService);
     }

--- a/dropwizard-app/src/test/java/org/coner/util/merger/ReflectionJavaBeanMergerTest.java
+++ b/dropwizard-app/src/test/java/org/coner/util/merger/ReflectionJavaBeanMergerTest.java
@@ -95,7 +95,7 @@ public class ReflectionJavaBeanMergerTest {
         private String propertyStringWithDestinationEnum;
         private Status propertyEnumWithStringDestination;
 
-        public TestSourceEntity(
+        TestSourceEntity(
                 String propertyCommon,
                 boolean propertyBoolean,
                 String propertyWithDifferentType,
@@ -197,7 +197,7 @@ public class ReflectionJavaBeanMergerTest {
             this.propertyStringWithDestinationEnum = propertyStringWithDestinationEnum;
         }
 
-        private static enum Status {
+        private enum Status {
             BUFFERING,
             PLAYING,
             PAUSED,
@@ -291,7 +291,7 @@ public class ReflectionJavaBeanMergerTest {
             this.propertyEnumWithStringDestination = propertyEnumWithStringDestination;
         }
 
-        private static enum Direction {
+        private enum Direction {
             NORTH,
             SOUTH,
             EAST,

--- a/dropwizard-app/src/test/resources/config/test.yml
+++ b/dropwizard-app/src/test/resources/config/test.yml
@@ -20,7 +20,5 @@ swagger:
 
 # Logging settings.
 logging:
-
     loggers:
-
         org.hibernate.SQL: ALL

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
+                <version>3.6.0</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -35,7 +35,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>2.13</version>
+                <version>2.17</version>
                 <configuration>
                     <configLocation>build-tools/src/main/resources/checkstyle/checkstyle.xml</configLocation>
                     <includeTestSourceDirectory>true</includeTestSourceDirectory>
@@ -51,13 +51,14 @@
                     <dependency>
                         <groupId>com.puppycrawl.tools</groupId>
                         <artifactId>checkstyle</artifactId>
-                        <version>6.2</version>
+                        <version>6.11.2</version>
                     </dependency>
                 </dependencies>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.10.4</version>
                 <configuration>
                     <additionalparam>-Xdoclint:none</additionalparam>
                 </configuration>
@@ -70,12 +71,12 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>versions-maven-plugin</artifactId>
-                <version>2.1</version>
+                <version>2.3</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>2.13</version>
+                <version>2.17</version>
                 <configuration>
                     <configLocation>build-tools/src/main/resources/checkstyle/checkstyle.xml</configLocation>
                     <linkXRef>false</linkXRef>
@@ -91,6 +92,14 @@
             <timezone>America/New_York</timezone>
             <roles>
                 <role>architect</role>
+                <role>committer</role>
+            </roles>
+        </developer>
+        <developer>
+            <name>James Short</name>
+            <url>https://github.com/jshort</url>
+            <timezone>America/Los_Angeles</timezone>
+            <roles>
                 <role>committer</role>
             </roles>
         </developer>


### PR DESCRIPTION
Given that active development on coner is about to startup again, I went
ahead and updated a lot of other dependencies.  I also made a lot of
checkstyle rules 'error' since we were already compliant and only marked
the few that we don't care about as 'warning'.

There were some changes necessary to get the DAO unit tests to work but
when the new DAOTestRule:

https://github.com/dropwizard/dropwizard/blob/master/dropwizard-testing/src/main/java/io/dropwizard/testing/junit/DAOTestRule.java

Is integrated into a release of dropwizard-testing, we can make use of
it in a very clean way.

Resolves #126