### PR TITLE
Checkstyle import overhaul.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: java
 jdk:
   - oraclejdk8
-script: mvn test && mvn checkstyle:check
+script: mvn test

--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -12,4 +12,7 @@
     <version>1.0</version>
     <name>Build Tools</name>
     <packaging>jar</packaging>
+    <properties>
+        <checkstyle.skip>true</checkstyle.skip>
+    </properties>
 </project>

--- a/build-tools/src/main/resources/checkstyle/checkstyle.xml
+++ b/build-tools/src/main/resources/checkstyle/checkstyle.xml
@@ -65,14 +65,16 @@
 
         <!-- Checks for imports                              -->
         <!-- See http://checkstyle.sf.net/config_imports.html -->
+        <module name="AvoidStarImport"/>
         <module name="IllegalImport"/> <!-- defaults to sun.* packages -->
         <module name="RedundantImport"/>
         <module name="UnusedImports"/>
         <module name="ImportOrder">
             <property name="severity" value="error"/>
-            <property name="groups" value="org.coner"/>
-            <property name="option" value="bottom"/>
+            <property name="groups" value="/^java\./,javax,org"/>
+            <property name="option" value="top"/>
             <property name="separated" value="true"/>
+            <property name="sortStaticImportsAlphabetically" value="true"/>
         </module>
 
 

--- a/dropwizard-api/src/main/java/org/coner/api/entity/CompetitionGroupApiEntity.java
+++ b/dropwizard-api/src/main/java/org/coner/api/entity/CompetitionGroupApiEntity.java
@@ -1,9 +1,16 @@
 package org.coner.api.entity;
 
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.math.BigDecimal;
-import javax.validation.constraints.*;
+
+import javax.validation.constraints.DecimalMax;
+import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.NotNull;
+
 import org.hibernate.validator.constraints.NotBlank;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
 
 @JsonPropertyOrder({"id", "name", "handicapFactor", "grouping", "resultTimeType"})
 public class CompetitionGroupApiEntity extends ApiEntity {

--- a/dropwizard-api/src/main/java/org/coner/api/entity/CompetitionGroupSetApiEntity.java
+++ b/dropwizard-api/src/main/java/org/coner/api/entity/CompetitionGroupSetApiEntity.java
@@ -1,7 +1,9 @@
 package org.coner.api.entity;
 
+import java.util.Objects;
+import java.util.Set;
+
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import java.util.*;
 
 @JsonPropertyOrder({"id", "name", "competitionGroups"})
 public class CompetitionGroupSetApiEntity extends ApiEntity {

--- a/dropwizard-api/src/main/java/org/coner/api/entity/EventApiEntity.java
+++ b/dropwizard-api/src/main/java/org/coner/api/entity/EventApiEntity.java
@@ -1,9 +1,13 @@
 package org.coner.api.entity;
 
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.util.Date;
-import javax.validation.constraints.*;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Null;
+
 import org.hibernate.validator.constraints.NotBlank;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 @JsonPropertyOrder({"id", "name", "date"})
 public class EventApiEntity extends ApiEntity {

--- a/dropwizard-api/src/main/java/org/coner/api/entity/HandicapGroupApiEntity.java
+++ b/dropwizard-api/src/main/java/org/coner/api/entity/HandicapGroupApiEntity.java
@@ -1,10 +1,15 @@
 package org.coner.api.entity;
 
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.math.BigDecimal;
 import java.util.Objects;
-import javax.validation.constraints.*;
+
+import javax.validation.constraints.DecimalMax;
+import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.NotNull;
+
 import org.hibernate.validator.constraints.NotBlank;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 @JsonPropertyOrder({"id", "name", "handicapFactor"})
 public class HandicapGroupApiEntity extends ApiEntity {

--- a/dropwizard-api/src/main/java/org/coner/api/entity/HandicapGroupSetApiEntity.java
+++ b/dropwizard-api/src/main/java/org/coner/api/entity/HandicapGroupSetApiEntity.java
@@ -1,7 +1,8 @@
 package org.coner.api.entity;
 
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.util.Set;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 @JsonPropertyOrder({"id", "name", "handicapGroups"})
 public class HandicapGroupSetApiEntity extends ApiEntity {

--- a/dropwizard-api/src/main/java/org/coner/api/entity/RegistrationApiEntity.java
+++ b/dropwizard-api/src/main/java/org/coner/api/entity/RegistrationApiEntity.java
@@ -1,8 +1,11 @@
 package org.coner.api.entity;
 
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import javax.validation.constraints.*;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Null;
+
 import org.hibernate.validator.constraints.NotBlank;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 @JsonPropertyOrder({"id", "firstName", "lastName", "event"})
 public class RegistrationApiEntity extends ApiEntity {

--- a/dropwizard-api/src/main/java/org/coner/api/request/AddCompetitionGroupRequest.java
+++ b/dropwizard-api/src/main/java/org/coner/api/request/AddCompetitionGroupRequest.java
@@ -2,7 +2,11 @@ package org.coner.api.request;
 
 import java.math.BigDecimal;
 import java.util.Objects;
-import javax.validation.constraints.*;
+
+import javax.validation.constraints.DecimalMax;
+import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.NotNull;
+
 import org.hibernate.validator.constraints.NotBlank;
 
 public class AddCompetitionGroupRequest {

--- a/dropwizard-api/src/main/java/org/coner/api/request/AddCompetitionGroupSetRequest.java
+++ b/dropwizard-api/src/main/java/org/coner/api/request/AddCompetitionGroupSetRequest.java
@@ -1,6 +1,7 @@
 package org.coner.api.request;
 
 import java.util.Set;
+
 import org.hibernate.validator.constraints.NotBlank;
 
 public class AddCompetitionGroupSetRequest {

--- a/dropwizard-api/src/main/java/org/coner/api/request/AddEventRequest.java
+++ b/dropwizard-api/src/main/java/org/coner/api/request/AddEventRequest.java
@@ -1,7 +1,10 @@
 package org.coner.api.request;
 
-import java.util.*;
+import java.util.Date;
+import java.util.Objects;
+
 import javax.validation.constraints.NotNull;
+
 import org.hibernate.validator.constraints.NotBlank;
 
 public class AddEventRequest {

--- a/dropwizard-api/src/main/java/org/coner/api/request/AddHandicapGroupRequest.java
+++ b/dropwizard-api/src/main/java/org/coner/api/request/AddHandicapGroupRequest.java
@@ -2,7 +2,11 @@ package org.coner.api.request;
 
 import java.math.BigDecimal;
 import java.util.Objects;
-import javax.validation.constraints.*;
+
+import javax.validation.constraints.DecimalMax;
+import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.NotNull;
+
 import org.hibernate.validator.constraints.NotBlank;
 
 public class AddHandicapGroupRequest {

--- a/dropwizard-api/src/main/java/org/coner/api/request/AddHandicapGroupSetRequest.java
+++ b/dropwizard-api/src/main/java/org/coner/api/request/AddHandicapGroupSetRequest.java
@@ -1,6 +1,7 @@
 package org.coner.api.request;
 
 import java.util.Set;
+
 import org.hibernate.validator.constraints.NotBlank;
 
 public class AddHandicapGroupSetRequest {

--- a/dropwizard-api/src/main/java/org/coner/api/request/AddRegistrationRequest.java
+++ b/dropwizard-api/src/main/java/org/coner/api/request/AddRegistrationRequest.java
@@ -1,6 +1,7 @@
 package org.coner.api.request;
 
 import java.util.Objects;
+
 import org.hibernate.validator.constraints.NotBlank;
 
 public class AddRegistrationRequest {

--- a/dropwizard-api/src/main/java/org/coner/api/response/ErrorsResponse.java
+++ b/dropwizard-api/src/main/java/org/coner/api/response/ErrorsResponse.java
@@ -1,7 +1,8 @@
 package org.coner.api.response;
 
-import com.google.common.collect.ImmutableList;
 import java.util.List;
+
+import com.google.common.collect.ImmutableList;
 
 public class ErrorsResponse {
 

--- a/dropwizard-api/src/main/java/org/coner/api/response/GetCompetitionGroupSetsResponse.java
+++ b/dropwizard-api/src/main/java/org/coner/api/response/GetCompetitionGroupSetsResponse.java
@@ -1,8 +1,8 @@
 package org.coner.api.response;
 
-import org.coner.api.entity.CompetitionGroupSetApiEntity;
-
 import java.util.List;
+
+import org.coner.api.entity.CompetitionGroupSetApiEntity;
 
 public class GetCompetitionGroupSetsResponse {
     private List<CompetitionGroupSetApiEntity> competitionGroupSets;

--- a/dropwizard-api/src/main/java/org/coner/api/response/GetCompetitionGroupsResponse.java
+++ b/dropwizard-api/src/main/java/org/coner/api/response/GetCompetitionGroupsResponse.java
@@ -1,8 +1,8 @@
 package org.coner.api.response;
 
-import org.coner.api.entity.CompetitionGroupApiEntity;
-
 import java.util.List;
+
+import org.coner.api.entity.CompetitionGroupApiEntity;
 
 public class GetCompetitionGroupsResponse {
     private List<CompetitionGroupApiEntity> competitionGroups;

--- a/dropwizard-api/src/main/java/org/coner/api/response/GetEventRegistrationsResponse.java
+++ b/dropwizard-api/src/main/java/org/coner/api/response/GetEventRegistrationsResponse.java
@@ -1,8 +1,8 @@
 package org.coner.api.response;
 
-import org.coner.api.entity.RegistrationApiEntity;
-
 import java.util.List;
+
+import org.coner.api.entity.RegistrationApiEntity;
 
 public class GetEventRegistrationsResponse {
 

--- a/dropwizard-api/src/main/java/org/coner/api/response/GetEventsResponse.java
+++ b/dropwizard-api/src/main/java/org/coner/api/response/GetEventsResponse.java
@@ -1,9 +1,9 @@
 package org.coner.api.response;
 
 
-import org.coner.api.entity.EventApiEntity;
-
 import java.util.List;
+
+import org.coner.api.entity.EventApiEntity;
 
 public class GetEventsResponse {
 

--- a/dropwizard-api/src/main/java/org/coner/api/response/GetHandicapGroupsResponse.java
+++ b/dropwizard-api/src/main/java/org/coner/api/response/GetHandicapGroupsResponse.java
@@ -1,8 +1,8 @@
 package org.coner.api.response;
 
-import org.coner.api.entity.HandicapGroupApiEntity;
-
 import java.util.List;
+
+import org.coner.api.entity.HandicapGroupApiEntity;
 
 public class GetHandicapGroupsResponse {
     private List<HandicapGroupApiEntity> handicapGroups;

--- a/dropwizard-app/src/main/java/org/coner/ConerDropwizardApplication.java
+++ b/dropwizard-app/src/main/java/org/coner/ConerDropwizardApplication.java
@@ -1,13 +1,25 @@
 package org.coner;
 
 import org.coner.exception.WebApplicationExceptionMapper;
-import org.coner.resource.*;
+import org.coner.resource.CompetitionGroupResource;
+import org.coner.resource.CompetitionGroupSetResource;
+import org.coner.resource.CompetitionGroupSetsResource;
+import org.coner.resource.CompetitionGroupsResource;
+import org.coner.resource.EventRegistrationResource;
+import org.coner.resource.EventRegistrationsResource;
+import org.coner.resource.EventResource;
+import org.coner.resource.EventsResource;
+import org.coner.resource.HandicapGroupResource;
+import org.coner.resource.HandicapGroupSetsResource;
+import org.coner.resource.HandicapGroupsResource;
 import org.coner.util.JacksonUtil;
 
 import io.dropwizard.Application;
 import io.dropwizard.jersey.setup.JerseyEnvironment;
-import io.dropwizard.setup.*;
-import io.federecio.dropwizard.swagger.*;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
+import io.federecio.dropwizard.swagger.SwaggerBundle;
+import io.federecio.dropwizard.swagger.SwaggerBundleConfiguration;
 
 public class ConerDropwizardApplication extends Application<ConerDropwizardConfiguration> {
 

--- a/dropwizard-app/src/main/java/org/coner/ConerDropwizardConfiguration.java
+++ b/dropwizard-app/src/main/java/org/coner/ConerDropwizardConfiguration.java
@@ -1,12 +1,13 @@
 package org.coner;
 
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.Configuration;
 import io.dropwizard.client.JerseyClientConfiguration;
 import io.dropwizard.db.DataSourceFactory;
 import io.federecio.dropwizard.swagger.SwaggerBundleConfiguration;
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
 
 public class ConerDropwizardConfiguration extends Configuration {
 

--- a/dropwizard-app/src/main/java/org/coner/ConerDropwizardDependencyContainer.java
+++ b/dropwizard-app/src/main/java/org/coner/ConerDropwizardDependencyContainer.java
@@ -1,17 +1,57 @@
 package org.coner;
 
-import org.coner.boundary.*;
+import java.util.Set;
+
+import org.coner.boundary.CompetitionGroupApiAddPayloadBoundary;
+import org.coner.boundary.CompetitionGroupApiDomainBoundary;
+import org.coner.boundary.CompetitionGroupHibernateAddPayloadBoundary;
+import org.coner.boundary.CompetitionGroupHibernateDomainBoundary;
+import org.coner.boundary.CompetitionGroupSetApiAddPayloadBoundary;
+import org.coner.boundary.CompetitionGroupSetApiDomainBoundary;
+import org.coner.boundary.CompetitionGroupSetHibernateAddPayloadBoundary;
+import org.coner.boundary.CompetitionGroupSetHibernateDomainBoundary;
+import org.coner.boundary.EventApiAddPayloadBoundary;
+import org.coner.boundary.EventApiDomainBoundary;
+import org.coner.boundary.EventHibernateAddPayloadBoundary;
+import org.coner.boundary.EventHibernateDomainBoundary;
+import org.coner.boundary.HandicapGroupApiAddPayloadBoundary;
+import org.coner.boundary.HandicapGroupApiDomainBoundary;
+import org.coner.boundary.HandicapGroupHibernateAddPayloadBoundary;
+import org.coner.boundary.HandicapGroupHibernateDomainBoundary;
+import org.coner.boundary.HandicapGroupSetApiAddPayloadBoundary;
+import org.coner.boundary.HandicapGroupSetApiDomainBoundary;
+import org.coner.boundary.HandicapGroupSetHibernateAddPayloadBoundary;
+import org.coner.boundary.HandicapGroupSetHibernateDomainBoundary;
+import org.coner.boundary.RegistrationApiAddPayloadBoundary;
+import org.coner.boundary.RegistrationApiDomainBoundary;
+import org.coner.boundary.RegistrationHibernateAddPayloadBoundary;
+import org.coner.boundary.RegistrationHibernateDomainBoundary;
 import org.coner.core.ConerCoreService;
-import org.coner.core.domain.service.*;
-import org.coner.core.gateway.*;
-import org.coner.hibernate.dao.*;
+import org.coner.core.domain.service.CompetitionGroupService;
+import org.coner.core.domain.service.CompetitionGroupSetService;
+import org.coner.core.domain.service.EventService;
+import org.coner.core.domain.service.HandicapGroupService;
+import org.coner.core.domain.service.HandicapGroupSetService;
+import org.coner.core.domain.service.RegistrationService;
+import org.coner.core.gateway.CompetitionGroupGateway;
+import org.coner.core.gateway.CompetitionGroupSetGateway;
+import org.coner.core.gateway.EventGateway;
+import org.coner.core.gateway.HandicapGroupGateway;
+import org.coner.core.gateway.HandicapGroupSetGateway;
+import org.coner.core.gateway.RegistrationGateway;
+import org.coner.hibernate.dao.CompetitionGroupDao;
+import org.coner.hibernate.dao.CompetitionGroupSetDao;
+import org.coner.hibernate.dao.EventDao;
+import org.coner.hibernate.dao.HandicapGroupDao;
+import org.coner.hibernate.dao.HandicapGroupSetDao;
+import org.coner.hibernate.dao.RegistrationDao;
 import org.coner.hibernate.entity.HibernateEntity;
+import org.reflections.Reflections;
 
 import com.google.common.collect.ImmutableList;
 import io.dropwizard.db.DataSourceFactory;
-import io.dropwizard.hibernate.*;
-import java.util.Set;
-import org.reflections.Reflections;
+import io.dropwizard.hibernate.HibernateBundle;
+import io.dropwizard.hibernate.SessionFactoryFactory;
 
 public class ConerDropwizardDependencyContainer {
 

--- a/dropwizard-app/src/main/java/org/coner/boundary/AbstractBoundary.java
+++ b/dropwizard-app/src/main/java/org/coner/boundary/AbstractBoundary.java
@@ -1,11 +1,16 @@
 package org.coner.boundary;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.coner.util.merger.ObjectMerger;
 
 import com.google.common.base.Preconditions;
-import java.lang.reflect.*;
-import java.util.*;
-import java.util.stream.Collectors;
 
 /**
  * AbstractBoundary provides sensible default behaviors for most boundary traversals, including instantiating

--- a/dropwizard-app/src/main/java/org/coner/boundary/CompetitionGroupApiAddPayloadBoundary.java
+++ b/dropwizard-app/src/main/java/org/coner/boundary/CompetitionGroupApiAddPayloadBoundary.java
@@ -2,7 +2,9 @@ package org.coner.boundary;
 
 import org.coner.api.request.AddCompetitionGroupRequest;
 import org.coner.core.domain.payload.CompetitionGroupAddPayload;
-import org.coner.util.merger.*;
+import org.coner.util.merger.ObjectMerger;
+import org.coner.util.merger.ReflectionPayloadJavaBeanMerger;
+import org.coner.util.merger.UnsupportedOperationMerger;
 
 public class CompetitionGroupApiAddPayloadBoundary extends AbstractBoundary<
         AddCompetitionGroupRequest,

--- a/dropwizard-app/src/main/java/org/coner/boundary/CompetitionGroupApiDomainBoundary.java
+++ b/dropwizard-app/src/main/java/org/coner/boundary/CompetitionGroupApiDomainBoundary.java
@@ -2,7 +2,8 @@ package org.coner.boundary;
 
 import org.coner.api.entity.CompetitionGroupApiEntity;
 import org.coner.core.domain.entity.CompetitionGroup;
-import org.coner.util.merger.*;
+import org.coner.util.merger.ObjectMerger;
+import org.coner.util.merger.ReflectionJavaBeanMerger;
 
 public class CompetitionGroupApiDomainBoundary extends AbstractBoundary<CompetitionGroupApiEntity, CompetitionGroup> {
     @Override

--- a/dropwizard-app/src/main/java/org/coner/boundary/CompetitionGroupHibernateAddPayloadBoundary.java
+++ b/dropwizard-app/src/main/java/org/coner/boundary/CompetitionGroupHibernateAddPayloadBoundary.java
@@ -2,7 +2,9 @@ package org.coner.boundary;
 
 import org.coner.core.domain.payload.CompetitionGroupAddPayload;
 import org.coner.hibernate.entity.CompetitionGroupHibernateEntity;
-import org.coner.util.merger.*;
+import org.coner.util.merger.ObjectMerger;
+import org.coner.util.merger.ReflectionPayloadJavaBeanMerger;
+import org.coner.util.merger.UnsupportedOperationMerger;
 
 public class CompetitionGroupHibernateAddPayloadBoundary extends AbstractBoundary<
         CompetitionGroupHibernateEntity,

--- a/dropwizard-app/src/main/java/org/coner/boundary/CompetitionGroupHibernateDomainBoundary.java
+++ b/dropwizard-app/src/main/java/org/coner/boundary/CompetitionGroupHibernateDomainBoundary.java
@@ -2,7 +2,8 @@ package org.coner.boundary;
 
 import org.coner.core.domain.entity.CompetitionGroup;
 import org.coner.hibernate.entity.CompetitionGroupHibernateEntity;
-import org.coner.util.merger.*;
+import org.coner.util.merger.ObjectMerger;
+import org.coner.util.merger.ReflectionJavaBeanMerger;
 
 public class CompetitionGroupHibernateDomainBoundary extends AbstractBoundary<
         CompetitionGroupHibernateEntity,

--- a/dropwizard-app/src/main/java/org/coner/boundary/CompetitionGroupSetApiAddPayloadBoundary.java
+++ b/dropwizard-app/src/main/java/org/coner/boundary/CompetitionGroupSetApiAddPayloadBoundary.java
@@ -2,7 +2,10 @@ package org.coner.boundary;
 
 import org.coner.api.request.AddCompetitionGroupSetRequest;
 import org.coner.core.domain.payload.CompetitionGroupSetAddPayload;
-import org.coner.util.merger.*;
+import org.coner.util.merger.CompositeMerger;
+import org.coner.util.merger.ObjectMerger;
+import org.coner.util.merger.ReflectionPayloadJavaBeanMerger;
+import org.coner.util.merger.UnsupportedOperationMerger;
 
 import com.google.common.collect.ImmutableSet;
 

--- a/dropwizard-app/src/main/java/org/coner/boundary/CompetitionGroupSetApiDomainBoundary.java
+++ b/dropwizard-app/src/main/java/org/coner/boundary/CompetitionGroupSetApiDomainBoundary.java
@@ -3,7 +3,8 @@ package org.coner.boundary;
 import org.coner.api.entity.CompetitionGroupSetApiEntity;
 import org.coner.api.request.AddCompetitionGroupSetRequest;
 import org.coner.core.domain.entity.CompetitionGroupSet;
-import org.coner.util.merger.*;
+import org.coner.util.merger.ObjectMerger;
+import org.coner.util.merger.ReflectionJavaBeanMerger;
 
 public class CompetitionGroupSetApiDomainBoundary extends AbstractBoundary<
         CompetitionGroupSetApiEntity,

--- a/dropwizard-app/src/main/java/org/coner/boundary/CompetitionGroupSetHibernateAddPayloadBoundary.java
+++ b/dropwizard-app/src/main/java/org/coner/boundary/CompetitionGroupSetHibernateAddPayloadBoundary.java
@@ -2,7 +2,9 @@ package org.coner.boundary;
 
 import org.coner.core.domain.payload.CompetitionGroupSetAddPayload;
 import org.coner.hibernate.entity.CompetitionGroupSetHibernateEntity;
-import org.coner.util.merger.*;
+import org.coner.util.merger.ObjectMerger;
+import org.coner.util.merger.ReflectionPayloadJavaBeanMerger;
+import org.coner.util.merger.UnsupportedOperationMerger;
 
 public class CompetitionGroupSetHibernateAddPayloadBoundary extends AbstractBoundary<
         CompetitionGroupSetHibernateEntity,

--- a/dropwizard-app/src/main/java/org/coner/boundary/CompetitionGroupSetHibernateDomainBoundary.java
+++ b/dropwizard-app/src/main/java/org/coner/boundary/CompetitionGroupSetHibernateDomainBoundary.java
@@ -2,7 +2,9 @@ package org.coner.boundary;
 
 import org.coner.core.domain.entity.CompetitionGroupSet;
 import org.coner.hibernate.entity.CompetitionGroupSetHibernateEntity;
-import org.coner.util.merger.*;
+import org.coner.util.merger.CompositeMerger;
+import org.coner.util.merger.ObjectMerger;
+import org.coner.util.merger.ReflectionJavaBeanMerger;
 
 public class CompetitionGroupSetHibernateDomainBoundary extends AbstractBoundary<
         CompetitionGroupSetHibernateEntity,

--- a/dropwizard-app/src/main/java/org/coner/boundary/EventApiAddPayloadBoundary.java
+++ b/dropwizard-app/src/main/java/org/coner/boundary/EventApiAddPayloadBoundary.java
@@ -2,7 +2,9 @@ package org.coner.boundary;
 
 import org.coner.api.request.AddEventRequest;
 import org.coner.core.domain.payload.EventAddPayload;
-import org.coner.util.merger.*;
+import org.coner.util.merger.ObjectMerger;
+import org.coner.util.merger.ReflectionPayloadJavaBeanMerger;
+import org.coner.util.merger.UnsupportedOperationMerger;
 
 public class EventApiAddPayloadBoundary extends AbstractBoundary<AddEventRequest, EventAddPayload> {
     @Override

--- a/dropwizard-app/src/main/java/org/coner/boundary/EventApiDomainBoundary.java
+++ b/dropwizard-app/src/main/java/org/coner/boundary/EventApiDomainBoundary.java
@@ -2,7 +2,8 @@ package org.coner.boundary;
 
 import org.coner.api.entity.EventApiEntity;
 import org.coner.core.domain.entity.Event;
-import org.coner.util.merger.*;
+import org.coner.util.merger.ObjectMerger;
+import org.coner.util.merger.ReflectionJavaBeanMerger;
 
 public class EventApiDomainBoundary extends AbstractBoundary<EventApiEntity, Event> {
     @Override

--- a/dropwizard-app/src/main/java/org/coner/boundary/EventHibernateAddPayloadBoundary.java
+++ b/dropwizard-app/src/main/java/org/coner/boundary/EventHibernateAddPayloadBoundary.java
@@ -2,7 +2,9 @@ package org.coner.boundary;
 
 import org.coner.core.domain.payload.EventAddPayload;
 import org.coner.hibernate.entity.EventHibernateEntity;
-import org.coner.util.merger.*;
+import org.coner.util.merger.ObjectMerger;
+import org.coner.util.merger.ReflectionPayloadJavaBeanMerger;
+import org.coner.util.merger.UnsupportedOperationMerger;
 
 public class EventHibernateAddPayloadBoundary extends AbstractBoundary<EventHibernateEntity, EventAddPayload> {
     @Override

--- a/dropwizard-app/src/main/java/org/coner/boundary/EventHibernateDomainBoundary.java
+++ b/dropwizard-app/src/main/java/org/coner/boundary/EventHibernateDomainBoundary.java
@@ -2,7 +2,8 @@ package org.coner.boundary;
 
 import org.coner.core.domain.entity.Event;
 import org.coner.hibernate.entity.EventHibernateEntity;
-import org.coner.util.merger.*;
+import org.coner.util.merger.ObjectMerger;
+import org.coner.util.merger.ReflectionJavaBeanMerger;
 
 public class EventHibernateDomainBoundary extends AbstractBoundary<EventHibernateEntity, Event> {
     @Override

--- a/dropwizard-app/src/main/java/org/coner/boundary/HandicapGroupApiAddPayloadBoundary.java
+++ b/dropwizard-app/src/main/java/org/coner/boundary/HandicapGroupApiAddPayloadBoundary.java
@@ -2,7 +2,9 @@ package org.coner.boundary;
 
 import org.coner.api.request.AddHandicapGroupRequest;
 import org.coner.core.domain.payload.HandicapGroupAddPayload;
-import org.coner.util.merger.*;
+import org.coner.util.merger.ObjectMerger;
+import org.coner.util.merger.ReflectionPayloadJavaBeanMerger;
+import org.coner.util.merger.UnsupportedOperationMerger;
 
 public class HandicapGroupApiAddPayloadBoundary extends AbstractBoundary<
         AddHandicapGroupRequest,

--- a/dropwizard-app/src/main/java/org/coner/boundary/HandicapGroupApiDomainBoundary.java
+++ b/dropwizard-app/src/main/java/org/coner/boundary/HandicapGroupApiDomainBoundary.java
@@ -2,7 +2,8 @@ package org.coner.boundary;
 
 import org.coner.api.entity.HandicapGroupApiEntity;
 import org.coner.core.domain.entity.HandicapGroup;
-import org.coner.util.merger.*;
+import org.coner.util.merger.ObjectMerger;
+import org.coner.util.merger.ReflectionJavaBeanMerger;
 
 public class HandicapGroupApiDomainBoundary extends AbstractBoundary<HandicapGroupApiEntity, HandicapGroup> {
     @Override

--- a/dropwizard-app/src/main/java/org/coner/boundary/HandicapGroupHibernateAddPayloadBoundary.java
+++ b/dropwizard-app/src/main/java/org/coner/boundary/HandicapGroupHibernateAddPayloadBoundary.java
@@ -2,7 +2,9 @@ package org.coner.boundary;
 
 import org.coner.core.domain.payload.HandicapGroupAddPayload;
 import org.coner.hibernate.entity.HandicapGroupHibernateEntity;
-import org.coner.util.merger.*;
+import org.coner.util.merger.ObjectMerger;
+import org.coner.util.merger.ReflectionPayloadJavaBeanMerger;
+import org.coner.util.merger.UnsupportedOperationMerger;
 
 public class HandicapGroupHibernateAddPayloadBoundary extends AbstractBoundary<
         HandicapGroupHibernateEntity,

--- a/dropwizard-app/src/main/java/org/coner/boundary/HandicapGroupHibernateDomainBoundary.java
+++ b/dropwizard-app/src/main/java/org/coner/boundary/HandicapGroupHibernateDomainBoundary.java
@@ -2,7 +2,8 @@ package org.coner.boundary;
 
 import org.coner.core.domain.entity.HandicapGroup;
 import org.coner.hibernate.entity.HandicapGroupHibernateEntity;
-import org.coner.util.merger.*;
+import org.coner.util.merger.ObjectMerger;
+import org.coner.util.merger.ReflectionJavaBeanMerger;
 
 public class HandicapGroupHibernateDomainBoundary extends AbstractBoundary<
         HandicapGroupHibernateEntity,

--- a/dropwizard-app/src/main/java/org/coner/boundary/HandicapGroupSetApiAddPayloadBoundary.java
+++ b/dropwizard-app/src/main/java/org/coner/boundary/HandicapGroupSetApiAddPayloadBoundary.java
@@ -2,7 +2,9 @@ package org.coner.boundary;
 
 import org.coner.api.request.AddHandicapGroupSetRequest;
 import org.coner.core.domain.payload.HandicapGroupSetAddPayload;
-import org.coner.util.merger.*;
+import org.coner.util.merger.ObjectMerger;
+import org.coner.util.merger.ReflectionPayloadJavaBeanMerger;
+import org.coner.util.merger.UnsupportedOperationMerger;
 
 public class HandicapGroupSetApiAddPayloadBoundary extends AbstractBoundary<
         AddHandicapGroupSetRequest,

--- a/dropwizard-app/src/main/java/org/coner/boundary/HandicapGroupSetApiDomainBoundary.java
+++ b/dropwizard-app/src/main/java/org/coner/boundary/HandicapGroupSetApiDomainBoundary.java
@@ -3,7 +3,8 @@ package org.coner.boundary;
 import org.coner.api.entity.HandicapGroupSetApiEntity;
 import org.coner.api.request.AddHandicapGroupSetRequest;
 import org.coner.core.domain.entity.HandicapGroupSet;
-import org.coner.util.merger.*;
+import org.coner.util.merger.ObjectMerger;
+import org.coner.util.merger.ReflectionJavaBeanMerger;
 
 public class HandicapGroupSetApiDomainBoundary extends AbstractBoundary<HandicapGroupSetApiEntity, HandicapGroupSet> {
 

--- a/dropwizard-app/src/main/java/org/coner/boundary/HandicapGroupSetHibernateAddPayloadBoundary.java
+++ b/dropwizard-app/src/main/java/org/coner/boundary/HandicapGroupSetHibernateAddPayloadBoundary.java
@@ -2,7 +2,9 @@ package org.coner.boundary;
 
 import org.coner.core.domain.payload.HandicapGroupSetAddPayload;
 import org.coner.hibernate.entity.HandicapGroupSetHibernateEntity;
-import org.coner.util.merger.*;
+import org.coner.util.merger.ObjectMerger;
+import org.coner.util.merger.ReflectionPayloadJavaBeanMerger;
+import org.coner.util.merger.UnsupportedOperationMerger;
 
 public class HandicapGroupSetHibernateAddPayloadBoundary extends AbstractBoundary<
         HandicapGroupSetHibernateEntity,

--- a/dropwizard-app/src/main/java/org/coner/boundary/HandicapGroupSetHibernateDomainBoundary.java
+++ b/dropwizard-app/src/main/java/org/coner/boundary/HandicapGroupSetHibernateDomainBoundary.java
@@ -2,7 +2,9 @@ package org.coner.boundary;
 
 import org.coner.core.domain.entity.HandicapGroupSet;
 import org.coner.hibernate.entity.HandicapGroupSetHibernateEntity;
-import org.coner.util.merger.*;
+import org.coner.util.merger.CompositeMerger;
+import org.coner.util.merger.ObjectMerger;
+import org.coner.util.merger.ReflectionJavaBeanMerger;
 
 public class HandicapGroupSetHibernateDomainBoundary extends AbstractBoundary<
         HandicapGroupSetHibernateEntity,

--- a/dropwizard-app/src/main/java/org/coner/boundary/RegistrationApiAddPayloadBoundary.java
+++ b/dropwizard-app/src/main/java/org/coner/boundary/RegistrationApiAddPayloadBoundary.java
@@ -2,7 +2,9 @@ package org.coner.boundary;
 
 import org.coner.api.request.AddRegistrationRequest;
 import org.coner.core.domain.payload.RegistrationAddPayload;
-import org.coner.util.merger.*;
+import org.coner.util.merger.ObjectMerger;
+import org.coner.util.merger.ReflectionPayloadJavaBeanMerger;
+import org.coner.util.merger.UnsupportedOperationMerger;
 
 public class RegistrationApiAddPayloadBoundary extends AbstractBoundary<
         AddRegistrationRequest,

--- a/dropwizard-app/src/main/java/org/coner/boundary/RegistrationApiDomainBoundary.java
+++ b/dropwizard-app/src/main/java/org/coner/boundary/RegistrationApiDomainBoundary.java
@@ -2,7 +2,8 @@ package org.coner.boundary;
 
 import org.coner.api.entity.RegistrationApiEntity;
 import org.coner.core.domain.entity.Registration;
-import org.coner.util.merger.*;
+import org.coner.util.merger.ObjectMerger;
+import org.coner.util.merger.ReflectionJavaBeanMerger;
 
 public class RegistrationApiDomainBoundary extends AbstractBoundary<RegistrationApiEntity, Registration> {
 

--- a/dropwizard-app/src/main/java/org/coner/boundary/RegistrationHibernateAddPayloadBoundary.java
+++ b/dropwizard-app/src/main/java/org/coner/boundary/RegistrationHibernateAddPayloadBoundary.java
@@ -2,7 +2,10 @@ package org.coner.boundary;
 
 import org.coner.core.domain.payload.RegistrationAddPayload;
 import org.coner.hibernate.entity.RegistrationHibernateEntity;
-import org.coner.util.merger.*;
+import org.coner.util.merger.CompositeMerger;
+import org.coner.util.merger.ObjectMerger;
+import org.coner.util.merger.ReflectionPayloadJavaBeanMerger;
+import org.coner.util.merger.UnsupportedOperationMerger;
 
 public class RegistrationHibernateAddPayloadBoundary extends AbstractBoundary<
         RegistrationHibernateEntity,

--- a/dropwizard-app/src/main/java/org/coner/boundary/RegistrationHibernateDomainBoundary.java
+++ b/dropwizard-app/src/main/java/org/coner/boundary/RegistrationHibernateDomainBoundary.java
@@ -2,7 +2,9 @@ package org.coner.boundary;
 
 import org.coner.core.domain.entity.Registration;
 import org.coner.hibernate.entity.RegistrationHibernateEntity;
-import org.coner.util.merger.*;
+import org.coner.util.merger.CompositeMerger;
+import org.coner.util.merger.ObjectMerger;
+import org.coner.util.merger.ReflectionJavaBeanMerger;
 
 public class RegistrationHibernateDomainBoundary extends AbstractBoundary<RegistrationHibernateEntity, Registration> {
 

--- a/dropwizard-app/src/main/java/org/coner/core/ConerCoreService.java
+++ b/dropwizard-app/src/main/java/org/coner/core/ConerCoreService.java
@@ -1,15 +1,32 @@
 package org.coner.core;
 
-import org.coner.core.domain.entity.*;
-import org.coner.core.domain.payload.*;
-import org.coner.core.domain.service.*;
-import org.coner.core.exception.*;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.List;
+
+import org.coner.core.domain.entity.CompetitionGroup;
+import org.coner.core.domain.entity.CompetitionGroupSet;
+import org.coner.core.domain.entity.Event;
+import org.coner.core.domain.entity.HandicapGroup;
+import org.coner.core.domain.entity.HandicapGroupSet;
+import org.coner.core.domain.entity.Registration;
+import org.coner.core.domain.payload.CompetitionGroupAddPayload;
+import org.coner.core.domain.payload.CompetitionGroupSetAddPayload;
+import org.coner.core.domain.payload.EventAddPayload;
+import org.coner.core.domain.payload.HandicapGroupAddPayload;
+import org.coner.core.domain.payload.HandicapGroupSetAddPayload;
+import org.coner.core.domain.payload.RegistrationAddPayload;
+import org.coner.core.domain.service.CompetitionGroupService;
+import org.coner.core.domain.service.CompetitionGroupSetService;
+import org.coner.core.domain.service.EventService;
+import org.coner.core.domain.service.HandicapGroupService;
+import org.coner.core.domain.service.HandicapGroupSetService;
+import org.coner.core.domain.service.RegistrationService;
+import org.coner.core.exception.EntityNotFoundException;
+import org.coner.core.exception.EventMismatchException;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
-import java.util.List;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 public class ConerCoreService {
 

--- a/dropwizard-app/src/main/java/org/coner/core/domain/payload/CompetitionGroupSetAddPayload.java
+++ b/dropwizard-app/src/main/java/org/coner/core/domain/payload/CompetitionGroupSetAddPayload.java
@@ -1,8 +1,8 @@
 package org.coner.core.domain.payload;
 
-import org.coner.core.domain.entity.CompetitionGroup;
-
 import java.util.Set;
+
+import org.coner.core.domain.entity.CompetitionGroup;
 
 public class CompetitionGroupSetAddPayload extends DomainAddPayload {
     public String name;

--- a/dropwizard-app/src/main/java/org/coner/core/domain/payload/EventAddPayload.java
+++ b/dropwizard-app/src/main/java/org/coner/core/domain/payload/EventAddPayload.java
@@ -1,6 +1,7 @@
 package org.coner.core.domain.payload;
 
-import java.util.*;
+import java.util.Date;
+import java.util.Objects;
 
 public class EventAddPayload extends DomainAddPayload {
     public String name;

--- a/dropwizard-app/src/main/java/org/coner/core/domain/service/AbstractDomainService.java
+++ b/dropwizard-app/src/main/java/org/coner/core/domain/service/AbstractDomainService.java
@@ -1,11 +1,11 @@
 package org.coner.core.domain.service;
 
+import java.util.List;
+
 import org.coner.core.domain.entity.DomainEntity;
 import org.coner.core.domain.payload.DomainAddPayload;
 import org.coner.core.exception.EntityNotFoundException;
 import org.coner.core.gateway.Gateway;
-
-import java.util.List;
 
 public abstract class AbstractDomainService<
         DE extends DomainEntity,

--- a/dropwizard-app/src/main/java/org/coner/core/domain/service/RegistrationService.java
+++ b/dropwizard-app/src/main/java/org/coner/core/domain/service/RegistrationService.java
@@ -1,11 +1,13 @@
 package org.coner.core.domain.service;
 
-import org.coner.core.domain.entity.*;
-import org.coner.core.domain.payload.RegistrationAddPayload;
-import org.coner.core.exception.*;
-import org.coner.core.gateway.RegistrationGateway;
-
 import java.util.List;
+
+import org.coner.core.domain.entity.Event;
+import org.coner.core.domain.entity.Registration;
+import org.coner.core.domain.payload.RegistrationAddPayload;
+import org.coner.core.exception.EntityNotFoundException;
+import org.coner.core.exception.EventMismatchException;
+import org.coner.core.gateway.RegistrationGateway;
 
 public class RegistrationService extends AbstractDomainService<
         Registration,

--- a/dropwizard-app/src/main/java/org/coner/core/gateway/AbstractGateway.java
+++ b/dropwizard-app/src/main/java/org/coner/core/gateway/AbstractGateway.java
@@ -1,13 +1,15 @@
 package org.coner.core.gateway;
 
+import java.util.List;
+
 import org.coner.boundary.AbstractBoundary;
 import org.coner.core.domain.entity.DomainEntity;
 import org.coner.core.domain.payload.DomainAddPayload;
 import org.coner.hibernate.dao.HibernateEntityDao;
 import org.coner.hibernate.entity.HibernateEntity;
 
-import com.google.common.base.*;
-import java.util.List;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 
 public abstract class AbstractGateway<
         DE extends DomainEntity,

--- a/dropwizard-app/src/main/java/org/coner/core/gateway/CompetitionGroupGateway.java
+++ b/dropwizard-app/src/main/java/org/coner/core/gateway/CompetitionGroupGateway.java
@@ -1,6 +1,7 @@
 package org.coner.core.gateway;
 
-import org.coner.boundary.*;
+import org.coner.boundary.CompetitionGroupHibernateAddPayloadBoundary;
+import org.coner.boundary.CompetitionGroupHibernateDomainBoundary;
 import org.coner.core.domain.entity.CompetitionGroup;
 import org.coner.core.domain.payload.CompetitionGroupAddPayload;
 import org.coner.hibernate.dao.CompetitionGroupDao;

--- a/dropwizard-app/src/main/java/org/coner/core/gateway/CompetitionGroupSetGateway.java
+++ b/dropwizard-app/src/main/java/org/coner/core/gateway/CompetitionGroupSetGateway.java
@@ -1,6 +1,7 @@
 package org.coner.core.gateway;
 
-import org.coner.boundary.*;
+import org.coner.boundary.CompetitionGroupSetHibernateAddPayloadBoundary;
+import org.coner.boundary.CompetitionGroupSetHibernateDomainBoundary;
 import org.coner.core.domain.entity.CompetitionGroupSet;
 import org.coner.core.domain.payload.CompetitionGroupSetAddPayload;
 import org.coner.hibernate.dao.CompetitionGroupSetDao;

--- a/dropwizard-app/src/main/java/org/coner/core/gateway/EventGateway.java
+++ b/dropwizard-app/src/main/java/org/coner/core/gateway/EventGateway.java
@@ -1,6 +1,7 @@
 package org.coner.core.gateway;
 
-import org.coner.boundary.*;
+import org.coner.boundary.EventHibernateAddPayloadBoundary;
+import org.coner.boundary.EventHibernateDomainBoundary;
 import org.coner.core.domain.entity.Event;
 import org.coner.core.domain.payload.EventAddPayload;
 import org.coner.hibernate.dao.EventDao;

--- a/dropwizard-app/src/main/java/org/coner/core/gateway/HandicapGroupGateway.java
+++ b/dropwizard-app/src/main/java/org/coner/core/gateway/HandicapGroupGateway.java
@@ -1,6 +1,7 @@
 package org.coner.core.gateway;
 
-import org.coner.boundary.*;
+import org.coner.boundary.HandicapGroupHibernateAddPayloadBoundary;
+import org.coner.boundary.HandicapGroupHibernateDomainBoundary;
 import org.coner.core.domain.entity.HandicapGroup;
 import org.coner.core.domain.payload.HandicapGroupAddPayload;
 import org.coner.hibernate.dao.HandicapGroupDao;

--- a/dropwizard-app/src/main/java/org/coner/core/gateway/HandicapGroupSetGateway.java
+++ b/dropwizard-app/src/main/java/org/coner/core/gateway/HandicapGroupSetGateway.java
@@ -1,6 +1,7 @@
 package org.coner.core.gateway;
 
-import org.coner.boundary.*;
+import org.coner.boundary.HandicapGroupSetHibernateAddPayloadBoundary;
+import org.coner.boundary.HandicapGroupSetHibernateDomainBoundary;
 import org.coner.core.domain.entity.HandicapGroupSet;
 import org.coner.core.domain.payload.HandicapGroupSetAddPayload;
 import org.coner.hibernate.dao.HandicapGroupSetDao;

--- a/dropwizard-app/src/main/java/org/coner/core/gateway/RegistrationGateway.java
+++ b/dropwizard-app/src/main/java/org/coner/core/gateway/RegistrationGateway.java
@@ -1,13 +1,18 @@
 package org.coner.core.gateway;
 
-import org.coner.boundary.*;
-import org.coner.core.domain.entity.*;
+import java.util.List;
+
+import org.coner.boundary.EventHibernateDomainBoundary;
+import org.coner.boundary.RegistrationHibernateAddPayloadBoundary;
+import org.coner.boundary.RegistrationHibernateDomainBoundary;
+import org.coner.core.domain.entity.Event;
+import org.coner.core.domain.entity.Registration;
 import org.coner.core.domain.payload.RegistrationAddPayload;
 import org.coner.hibernate.dao.RegistrationDao;
-import org.coner.hibernate.entity.*;
+import org.coner.hibernate.entity.EventHibernateEntity;
+import org.coner.hibernate.entity.RegistrationHibernateEntity;
 
 import com.google.common.base.Preconditions;
-import java.util.List;
 
 public class RegistrationGateway extends AbstractGateway<
         Registration,

--- a/dropwizard-app/src/main/java/org/coner/exception/WebApplicationExceptionMapper.java
+++ b/dropwizard-app/src/main/java/org/coner/exception/WebApplicationExceptionMapper.java
@@ -1,12 +1,15 @@
 package org.coner.exception;
 
+import java.util.Arrays;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
 import org.coner.api.response.ErrorsResponse;
 
 import com.google.common.base.Strings;
-import java.util.Arrays;
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.*;
-import javax.ws.rs.ext.ExceptionMapper;
 
 public class WebApplicationExceptionMapper implements ExceptionMapper<WebApplicationException> {
     @Override

--- a/dropwizard-app/src/main/java/org/coner/hibernate/dao/CompetitionGroupDao.java
+++ b/dropwizard-app/src/main/java/org/coner/hibernate/dao/CompetitionGroupDao.java
@@ -1,10 +1,11 @@
 package org.coner.hibernate.dao;
 
+import java.util.List;
+
 import org.coner.hibernate.entity.CompetitionGroupHibernateEntity;
+import org.hibernate.SessionFactory;
 
 import io.dropwizard.hibernate.AbstractDAO;
-import java.util.List;
-import org.hibernate.SessionFactory;
 
 public class CompetitionGroupDao
         extends AbstractDAO<CompetitionGroupHibernateEntity>

--- a/dropwizard-app/src/main/java/org/coner/hibernate/dao/CompetitionGroupSetDao.java
+++ b/dropwizard-app/src/main/java/org/coner/hibernate/dao/CompetitionGroupSetDao.java
@@ -1,10 +1,11 @@
 package org.coner.hibernate.dao;
 
+import java.util.List;
+
 import org.coner.hibernate.entity.CompetitionGroupSetHibernateEntity;
+import org.hibernate.SessionFactory;
 
 import io.dropwizard.hibernate.AbstractDAO;
-import java.util.List;
-import org.hibernate.SessionFactory;
 
 public class CompetitionGroupSetDao
         extends AbstractDAO<CompetitionGroupSetHibernateEntity>

--- a/dropwizard-app/src/main/java/org/coner/hibernate/dao/EventDao.java
+++ b/dropwizard-app/src/main/java/org/coner/hibernate/dao/EventDao.java
@@ -1,10 +1,11 @@
 package org.coner.hibernate.dao;
 
+import java.util.List;
+
 import org.coner.hibernate.entity.EventHibernateEntity;
+import org.hibernate.SessionFactory;
 
 import io.dropwizard.hibernate.AbstractDAO;
-import java.util.List;
-import org.hibernate.SessionFactory;
 
 public class EventDao
         extends AbstractDAO<EventHibernateEntity>

--- a/dropwizard-app/src/main/java/org/coner/hibernate/dao/HandicapGroupDao.java
+++ b/dropwizard-app/src/main/java/org/coner/hibernate/dao/HandicapGroupDao.java
@@ -1,10 +1,11 @@
 package org.coner.hibernate.dao;
 
+import java.util.List;
+
 import org.coner.hibernate.entity.HandicapGroupHibernateEntity;
+import org.hibernate.SessionFactory;
 
 import io.dropwizard.hibernate.AbstractDAO;
-import java.util.List;
-import org.hibernate.SessionFactory;
 
 public class HandicapGroupDao
         extends AbstractDAO<HandicapGroupHibernateEntity>

--- a/dropwizard-app/src/main/java/org/coner/hibernate/dao/HandicapGroupSetDao.java
+++ b/dropwizard-app/src/main/java/org/coner/hibernate/dao/HandicapGroupSetDao.java
@@ -1,10 +1,11 @@
 package org.coner.hibernate.dao;
 
+import java.util.List;
+
 import org.coner.hibernate.entity.HandicapGroupSetHibernateEntity;
+import org.hibernate.SessionFactory;
 
 import io.dropwizard.hibernate.AbstractDAO;
-import java.util.List;
-import org.hibernate.SessionFactory;
 
 public class HandicapGroupSetDao
         extends AbstractDAO<HandicapGroupSetHibernateEntity>

--- a/dropwizard-app/src/main/java/org/coner/hibernate/dao/HibernateEntityDao.java
+++ b/dropwizard-app/src/main/java/org/coner/hibernate/dao/HibernateEntityDao.java
@@ -1,8 +1,8 @@
 package org.coner.hibernate.dao;
 
-import org.coner.hibernate.entity.HibernateEntity;
-
 import java.util.List;
+
+import org.coner.hibernate.entity.HibernateEntity;
 
 public interface HibernateEntityDao<HE extends HibernateEntity> {
     void create(HE entity);

--- a/dropwizard-app/src/main/java/org/coner/hibernate/dao/RegistrationDao.java
+++ b/dropwizard-app/src/main/java/org/coner/hibernate/dao/RegistrationDao.java
@@ -1,10 +1,13 @@
 package org.coner.hibernate.dao;
 
-import org.coner.hibernate.entity.*;
+import java.util.List;
+
+import org.coner.hibernate.entity.EventHibernateEntity;
+import org.coner.hibernate.entity.RegistrationHibernateEntity;
+import org.hibernate.Query;
+import org.hibernate.SessionFactory;
 
 import io.dropwizard.hibernate.AbstractDAO;
-import java.util.List;
-import org.hibernate.*;
 
 public class RegistrationDao
         extends AbstractDAO<RegistrationHibernateEntity>

--- a/dropwizard-app/src/main/java/org/coner/hibernate/entity/CompetitionGroupHibernateEntity.java
+++ b/dropwizard-app/src/main/java/org/coner/hibernate/entity/CompetitionGroupHibernateEntity.java
@@ -2,7 +2,20 @@ package org.coner.hibernate.entity;
 
 import java.math.BigDecimal;
 import java.util.Set;
-import javax.persistence.*;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinTable;
+import javax.persistence.ManyToMany;
+import javax.persistence.NamedQueries;
+import javax.persistence.NamedQuery;
+import javax.persistence.Table;
+
 import org.hibernate.annotations.GenericGenerator;
 
 @Entity

--- a/dropwizard-app/src/main/java/org/coner/hibernate/entity/CompetitionGroupSetHibernateEntity.java
+++ b/dropwizard-app/src/main/java/org/coner/hibernate/entity/CompetitionGroupSetHibernateEntity.java
@@ -1,7 +1,17 @@
 package org.coner.hibernate.entity;
 
 import java.util.Set;
-import javax.persistence.*;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.ManyToMany;
+import javax.persistence.NamedQueries;
+import javax.persistence.NamedQuery;
+import javax.persistence.Table;
+
 import org.hibernate.annotations.GenericGenerator;
 
 @Entity

--- a/dropwizard-app/src/main/java/org/coner/hibernate/entity/EventHibernateEntity.java
+++ b/dropwizard-app/src/main/java/org/coner/hibernate/entity/EventHibernateEntity.java
@@ -1,7 +1,17 @@
 package org.coner.hibernate.entity;
 
 import java.util.Date;
-import javax.persistence.*;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.NamedQueries;
+import javax.persistence.NamedQuery;
+import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+
 import org.hibernate.annotations.GenericGenerator;
 
 @Entity

--- a/dropwizard-app/src/main/java/org/coner/hibernate/entity/HandicapGroupHibernateEntity.java
+++ b/dropwizard-app/src/main/java/org/coner/hibernate/entity/HandicapGroupHibernateEntity.java
@@ -2,7 +2,20 @@ package org.coner.hibernate.entity;
 
 import java.math.BigDecimal;
 import java.util.Set;
-import javax.persistence.*;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinTable;
+import javax.persistence.ManyToMany;
+import javax.persistence.NamedQueries;
+import javax.persistence.NamedQuery;
+import javax.persistence.Table;
+
 import org.hibernate.annotations.GenericGenerator;
 
 @Entity

--- a/dropwizard-app/src/main/java/org/coner/hibernate/entity/HandicapGroupSetHibernateEntity.java
+++ b/dropwizard-app/src/main/java/org/coner/hibernate/entity/HandicapGroupSetHibernateEntity.java
@@ -1,7 +1,15 @@
 package org.coner.hibernate.entity;
 
 import java.util.Set;
-import javax.persistence.*;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.ManyToMany;
+import javax.persistence.Table;
+
 import org.hibernate.annotations.GenericGenerator;
 
 @Entity

--- a/dropwizard-app/src/main/java/org/coner/hibernate/entity/RegistrationHibernateEntity.java
+++ b/dropwizard-app/src/main/java/org/coner/hibernate/entity/RegistrationHibernateEntity.java
@@ -1,6 +1,14 @@
 package org.coner.hibernate.entity;
 
-import javax.persistence.*;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.NamedQueries;
+import javax.persistence.NamedQuery;
+import javax.persistence.Table;
+
 import org.hibernate.annotations.GenericGenerator;
 
 @Entity

--- a/dropwizard-app/src/main/java/org/coner/resource/CompetitionGroupResource.java
+++ b/dropwizard-app/src/main/java/org/coner/resource/CompetitionGroupResource.java
@@ -1,17 +1,27 @@
 package org.coner.resource;
 
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
 import org.coner.api.entity.CompetitionGroupApiEntity;
 import org.coner.api.response.ErrorsResponse;
 import org.coner.boundary.CompetitionGroupApiDomainBoundary;
 import org.coner.core.ConerCoreService;
 import org.coner.core.domain.entity.CompetitionGroup;
 import org.coner.core.exception.EntityNotFoundException;
+import org.eclipse.jetty.http.HttpStatus;
 
 import io.dropwizard.hibernate.UnitOfWork;
-import io.swagger.annotations.*;
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
-import org.eclipse.jetty.http.HttpStatus;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 
 @Path("/competitionGroups/{competitionGroupId}")
 @Produces(MediaType.APPLICATION_JSON)

--- a/dropwizard-app/src/main/java/org/coner/resource/CompetitionGroupSetResource.java
+++ b/dropwizard-app/src/main/java/org/coner/resource/CompetitionGroupSetResource.java
@@ -1,17 +1,28 @@
 package org.coner.resource;
 
-import org.coner.api.entity.*;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.coner.api.entity.CompetitionGroupApiEntity;
+import org.coner.api.entity.CompetitionGroupSetApiEntity;
 import org.coner.api.response.ErrorsResponse;
 import org.coner.boundary.CompetitionGroupSetApiDomainBoundary;
 import org.coner.core.ConerCoreService;
 import org.coner.core.domain.entity.CompetitionGroupSet;
 import org.coner.core.exception.EntityNotFoundException;
+import org.eclipse.jetty.http.HttpStatus;
 
 import io.dropwizard.hibernate.UnitOfWork;
-import io.swagger.annotations.*;
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
-import org.eclipse.jetty.http.HttpStatus;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 
 @Path("/competitionGroups/sets/{competitionGroupSetId}")
 @Consumes(MediaType.APPLICATION_JSON)

--- a/dropwizard-app/src/main/java/org/coner/resource/CompetitionGroupSetsResource.java
+++ b/dropwizard-app/src/main/java/org/coner/resource/CompetitionGroupSetsResource.java
@@ -1,21 +1,36 @@
 package org.coner.resource;
 
+import java.util.List;
+
+import javax.validation.Valid;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+
 import org.coner.api.entity.CompetitionGroupSetApiEntity;
 import org.coner.api.request.AddCompetitionGroupSetRequest;
-import org.coner.api.response.*;
-import org.coner.boundary.*;
+import org.coner.api.response.ErrorsResponse;
+import org.coner.api.response.GetCompetitionGroupSetsResponse;
+import org.coner.boundary.CompetitionGroupSetApiAddPayloadBoundary;
+import org.coner.boundary.CompetitionGroupSetApiDomainBoundary;
 import org.coner.core.ConerCoreService;
 import org.coner.core.domain.entity.CompetitionGroupSet;
 import org.coner.core.domain.payload.CompetitionGroupSetAddPayload;
 import org.coner.core.exception.EntityNotFoundException;
+import org.eclipse.jetty.http.HttpStatus;
 
 import io.dropwizard.hibernate.UnitOfWork;
-import io.swagger.annotations.*;
-import java.util.List;
-import javax.validation.Valid;
-import javax.ws.rs.*;
-import javax.ws.rs.core.*;
-import org.eclipse.jetty.http.HttpStatus;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.ResponseHeader;
 
 @Path("/competitionGroups/sets")
 @Produces(MediaType.APPLICATION_JSON)

--- a/dropwizard-app/src/main/java/org/coner/resource/CompetitionGroupsResource.java
+++ b/dropwizard-app/src/main/java/org/coner/resource/CompetitionGroupsResource.java
@@ -1,20 +1,34 @@
 package org.coner.resource;
 
+import java.util.List;
+
+import javax.validation.Valid;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+
 import org.coner.api.entity.CompetitionGroupApiEntity;
 import org.coner.api.request.AddCompetitionGroupRequest;
-import org.coner.api.response.*;
-import org.coner.boundary.*;
+import org.coner.api.response.ErrorsResponse;
+import org.coner.api.response.GetCompetitionGroupsResponse;
+import org.coner.boundary.CompetitionGroupApiAddPayloadBoundary;
+import org.coner.boundary.CompetitionGroupApiDomainBoundary;
 import org.coner.core.ConerCoreService;
 import org.coner.core.domain.entity.CompetitionGroup;
 import org.coner.core.domain.payload.CompetitionGroupAddPayload;
+import org.eclipse.jetty.http.HttpStatus;
 
 import io.dropwizard.hibernate.UnitOfWork;
-import io.swagger.annotations.*;
-import java.util.List;
-import javax.validation.Valid;
-import javax.ws.rs.*;
-import javax.ws.rs.core.*;
-import org.eclipse.jetty.http.HttpStatus;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 
 @Path("/competitionGroups")
 @Produces(MediaType.APPLICATION_JSON)

--- a/dropwizard-app/src/main/java/org/coner/resource/EventRegistrationResource.java
+++ b/dropwizard-app/src/main/java/org/coner/resource/EventRegistrationResource.java
@@ -1,17 +1,29 @@
 package org.coner.resource;
 
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
 import org.coner.api.entity.RegistrationApiEntity;
 import org.coner.api.response.ErrorsResponse;
 import org.coner.boundary.RegistrationApiDomainBoundary;
 import org.coner.core.ConerCoreService;
 import org.coner.core.domain.entity.Registration;
-import org.coner.core.exception.*;
+import org.coner.core.exception.EntityNotFoundException;
+import org.coner.core.exception.EventMismatchException;
+import org.eclipse.jetty.http.HttpStatus;
 
 import io.dropwizard.hibernate.UnitOfWork;
-import io.swagger.annotations.*;
-import javax.ws.rs.*;
-import javax.ws.rs.core.*;
-import org.eclipse.jetty.http.HttpStatus;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 
 @Path("/events/{eventId}/registrations/{registrationId}")
 @Produces(MediaType.APPLICATION_JSON)

--- a/dropwizard-app/src/main/java/org/coner/resource/EventRegistrationsResource.java
+++ b/dropwizard-app/src/main/java/org/coner/resource/EventRegistrationsResource.java
@@ -1,21 +1,37 @@
 package org.coner.resource;
 
+import java.util.List;
+
+import javax.validation.Valid;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+
 import org.coner.api.entity.RegistrationApiEntity;
 import org.coner.api.request.AddRegistrationRequest;
-import org.coner.api.response.*;
-import org.coner.boundary.*;
+import org.coner.api.response.ErrorsResponse;
+import org.coner.api.response.GetEventRegistrationsResponse;
+import org.coner.boundary.RegistrationApiAddPayloadBoundary;
+import org.coner.boundary.RegistrationApiDomainBoundary;
 import org.coner.core.ConerCoreService;
 import org.coner.core.domain.entity.Registration;
 import org.coner.core.domain.payload.RegistrationAddPayload;
 import org.coner.core.exception.EntityNotFoundException;
+import org.eclipse.jetty.http.HttpStatus;
 
 import io.dropwizard.hibernate.UnitOfWork;
-import io.swagger.annotations.*;
-import java.util.List;
-import javax.validation.Valid;
-import javax.ws.rs.*;
-import javax.ws.rs.core.*;
-import org.eclipse.jetty.http.HttpStatus;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 
 @Path("/events/{eventId}/registrations")
 @Produces(MediaType.APPLICATION_JSON)

--- a/dropwizard-app/src/main/java/org/coner/resource/EventResource.java
+++ b/dropwizard-app/src/main/java/org/coner/resource/EventResource.java
@@ -1,17 +1,27 @@
 package org.coner.resource;
 
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
 import org.coner.api.entity.EventApiEntity;
 import org.coner.api.response.ErrorsResponse;
 import org.coner.boundary.EventApiDomainBoundary;
 import org.coner.core.ConerCoreService;
 import org.coner.core.domain.entity.Event;
 import org.coner.core.exception.EntityNotFoundException;
+import org.eclipse.jetty.http.HttpStatus;
 
 import io.dropwizard.hibernate.UnitOfWork;
-import io.swagger.annotations.*;
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
-import org.eclipse.jetty.http.HttpStatus;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 
 @Path("/events/{eventId}")
 @Produces(MediaType.APPLICATION_JSON)

--- a/dropwizard-app/src/main/java/org/coner/resource/EventsResource.java
+++ b/dropwizard-app/src/main/java/org/coner/resource/EventsResource.java
@@ -1,20 +1,34 @@
 package org.coner.resource;
 
+import java.util.List;
+
+import javax.validation.Valid;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+
 import org.coner.api.entity.EventApiEntity;
 import org.coner.api.request.AddEventRequest;
-import org.coner.api.response.*;
-import org.coner.boundary.*;
+import org.coner.api.response.ErrorsResponse;
+import org.coner.api.response.GetEventsResponse;
+import org.coner.boundary.EventApiAddPayloadBoundary;
+import org.coner.boundary.EventApiDomainBoundary;
 import org.coner.core.ConerCoreService;
 import org.coner.core.domain.entity.Event;
 import org.coner.core.domain.payload.EventAddPayload;
+import org.eclipse.jetty.http.HttpStatus;
 
 import io.dropwizard.hibernate.UnitOfWork;
-import io.swagger.annotations.*;
-import java.util.List;
-import javax.validation.Valid;
-import javax.ws.rs.*;
-import javax.ws.rs.core.*;
-import org.eclipse.jetty.http.HttpStatus;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 
 @Path("/events")
 @Produces(MediaType.APPLICATION_JSON)

--- a/dropwizard-app/src/main/java/org/coner/resource/HandicapGroupResource.java
+++ b/dropwizard-app/src/main/java/org/coner/resource/HandicapGroupResource.java
@@ -1,17 +1,27 @@
 package org.coner.resource;
 
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
 import org.coner.api.entity.HandicapGroupApiEntity;
 import org.coner.api.response.ErrorsResponse;
 import org.coner.boundary.HandicapGroupApiDomainBoundary;
 import org.coner.core.ConerCoreService;
 import org.coner.core.domain.entity.HandicapGroup;
 import org.coner.core.exception.EntityNotFoundException;
+import org.eclipse.jetty.http.HttpStatus;
 
 import io.dropwizard.hibernate.UnitOfWork;
-import io.swagger.annotations.*;
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
-import org.eclipse.jetty.http.HttpStatus;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 
 @Path("/handicapGroups/{handicapGroupId}")
 @Produces(MediaType.APPLICATION_JSON)

--- a/dropwizard-app/src/main/java/org/coner/resource/HandicapGroupSetsResource.java
+++ b/dropwizard-app/src/main/java/org/coner/resource/HandicapGroupSetsResource.java
@@ -1,20 +1,32 @@
 package org.coner.resource;
 
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+
 import org.coner.api.entity.HandicapGroupSetApiEntity;
 import org.coner.api.request.AddHandicapGroupSetRequest;
 import org.coner.api.response.ErrorsResponse;
-import org.coner.boundary.*;
+import org.coner.boundary.HandicapGroupSetApiAddPayloadBoundary;
+import org.coner.boundary.HandicapGroupSetApiDomainBoundary;
 import org.coner.core.ConerCoreService;
 import org.coner.core.domain.entity.HandicapGroupSet;
 import org.coner.core.domain.payload.HandicapGroupSetAddPayload;
+import org.eclipse.jetty.http.HttpStatus;
 
 import io.dropwizard.hibernate.UnitOfWork;
-import io.swagger.annotations.*;
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
-import javax.ws.rs.*;
-import javax.ws.rs.core.*;
-import org.eclipse.jetty.http.HttpStatus;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.ResponseHeader;
 
 @Path("/handicapGroups/sets")
 @Produces(MediaType.APPLICATION_JSON)

--- a/dropwizard-app/src/main/java/org/coner/resource/HandicapGroupsResource.java
+++ b/dropwizard-app/src/main/java/org/coner/resource/HandicapGroupsResource.java
@@ -1,20 +1,34 @@
 package org.coner.resource;
 
+import java.util.List;
+
+import javax.validation.Valid;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+
 import org.coner.api.entity.HandicapGroupApiEntity;
 import org.coner.api.request.AddHandicapGroupRequest;
-import org.coner.api.response.*;
-import org.coner.boundary.*;
+import org.coner.api.response.ErrorsResponse;
+import org.coner.api.response.GetHandicapGroupsResponse;
+import org.coner.boundary.HandicapGroupApiAddPayloadBoundary;
+import org.coner.boundary.HandicapGroupApiDomainBoundary;
 import org.coner.core.ConerCoreService;
 import org.coner.core.domain.entity.HandicapGroup;
 import org.coner.core.domain.payload.HandicapGroupAddPayload;
+import org.eclipse.jetty.http.HttpStatus;
 
 import io.dropwizard.hibernate.UnitOfWork;
-import io.swagger.annotations.*;
-import java.util.List;
-import javax.validation.Valid;
-import javax.ws.rs.*;
-import javax.ws.rs.core.*;
-import org.eclipse.jetty.http.HttpStatus;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 
 @Path("/handicapGroups")
 @Produces(MediaType.APPLICATION_JSON)

--- a/dropwizard-app/src/main/java/org/coner/util/merger/JavaBeanClassInspector.java
+++ b/dropwizard-app/src/main/java/org/coner/util/merger/JavaBeanClassInspector.java
@@ -1,8 +1,11 @@
 package org.coner.util.merger;
 
-import com.google.common.collect.*;
 import java.lang.reflect.Method;
-import java.util.*;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 
 public final class JavaBeanClassInspector {
 

--- a/dropwizard-app/src/main/java/org/coner/util/merger/PayloadClassInspector.java
+++ b/dropwizard-app/src/main/java/org/coner/util/merger/PayloadClassInspector.java
@@ -1,7 +1,8 @@
 package org.coner.util.merger;
 
-import com.google.common.collect.ImmutableMap;
 import java.lang.reflect.Field;
+
+import com.google.common.collect.ImmutableMap;
 
 public final class PayloadClassInspector {
 

--- a/dropwizard-app/src/main/java/org/coner/util/merger/ReflectionJavaBeanMerger.java
+++ b/dropwizard-app/src/main/java/org/coner/util/merger/ReflectionJavaBeanMerger.java
@@ -1,7 +1,9 @@
 package org.coner.util.merger;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
 import com.google.common.collect.ImmutableList;
-import java.lang.reflect.*;
 
 /**
  * ReflectionJavaBeanMerger uses reflection to automatically merge objects that follow the JavaBean convention.

--- a/dropwizard-app/src/main/java/org/coner/util/merger/ReflectionPayloadJavaBeanMerger.java
+++ b/dropwizard-app/src/main/java/org/coner/util/merger/ReflectionPayloadJavaBeanMerger.java
@@ -1,7 +1,10 @@
 package org.coner.util.merger;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
 import com.google.common.collect.ImmutableList;
-import java.lang.reflect.*;
 
 public class ReflectionPayloadJavaBeanMerger<S, D> implements ObjectMerger<S, D> {
     private final Direction direction;

--- a/dropwizard-app/src/test/java/org/coner/ConerDropwizardApplicationTest.java
+++ b/dropwizard-app/src/test/java/org/coner/ConerDropwizardApplicationTest.java
@@ -1,28 +1,52 @@
 package org.coner;
 
-import org.coner.boundary.*;
-import org.coner.core.ConerCoreService;
-import org.coner.core.gateway.*;
-import org.coner.exception.WebApplicationExceptionMapper;
-import org.coner.hibernate.dao.*;
-import org.coner.resource.*;
-
-import com.fasterxml.jackson.databind.*;
-import io.dropwizard.db.DataSourceFactory;
-import io.dropwizard.hibernate.HibernateBundle;
-import io.dropwizard.jersey.setup.JerseyEnvironment;
-import io.dropwizard.setup.*;
-import java.util.*;
-import java.util.stream.Collectors;
-import org.junit.*;
-import org.junit.runner.RunWith;
-import org.mockito.*;
-import org.mockito.runners.MockitoJUnitRunner;
-
 import static org.fest.assertions.Assertions.assertThat;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.coner.boundary.CompetitionGroupApiDomainBoundary;
+import org.coner.boundary.EventApiDomainBoundary;
+import org.coner.boundary.HandicapGroupApiDomainBoundary;
+import org.coner.boundary.RegistrationApiDomainBoundary;
+import org.coner.core.ConerCoreService;
+import org.coner.core.gateway.CompetitionGroupGateway;
+import org.coner.core.gateway.EventGateway;
+import org.coner.core.gateway.HandicapGroupGateway;
+import org.coner.core.gateway.RegistrationGateway;
+import org.coner.exception.WebApplicationExceptionMapper;
+import org.coner.hibernate.dao.CompetitionGroupDao;
+import org.coner.hibernate.dao.EventDao;
+import org.coner.hibernate.dao.HandicapGroupDao;
+import org.coner.hibernate.dao.RegistrationDao;
+import org.coner.resource.CompetitionGroupResource;
+import org.coner.resource.CompetitionGroupSetsResource;
+import org.coner.resource.CompetitionGroupsResource;
+import org.coner.resource.EventRegistrationResource;
+import org.coner.resource.EventRegistrationsResource;
+import org.coner.resource.EventResource;
+import org.coner.resource.EventsResource;
+import org.coner.resource.HandicapGroupResource;
+import org.coner.resource.HandicapGroupSetsResource;
+import org.coner.resource.HandicapGroupsResource;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import io.dropwizard.db.DataSourceFactory;
+import io.dropwizard.hibernate.HibernateBundle;
+import io.dropwizard.jersey.setup.JerseyEnvironment;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ConerDropwizardApplicationTest {

--- a/dropwizard-app/src/test/java/org/coner/api/entity/CompetitionGroupApiEntityTest.java
+++ b/dropwizard-app/src/test/java/org/coner/api/entity/CompetitionGroupApiEntityTest.java
@@ -1,13 +1,15 @@
 package org.coner.api.entity;
 
-import org.coner.util.*;
+import org.assertj.core.api.Assertions;
+import org.coner.util.ApiEntityTestUtils;
+import org.coner.util.JacksonUtil;
+import org.junit.Before;
+import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.jackson.Jackson;
 import io.dropwizard.testing.FixtureHelpers;
-import org.assertj.core.api.Assertions;
-import org.junit.*;
-import org.skyscreamer.jsonassert.JSONAssert;
 
 public class CompetitionGroupApiEntityTest {
     private final String fixturePath = "fixtures/api/entity/competition_group_full.json";

--- a/dropwizard-app/src/test/java/org/coner/api/entity/EventApiEntityTest.java
+++ b/dropwizard-app/src/test/java/org/coner/api/entity/EventApiEntityTest.java
@@ -1,14 +1,16 @@
 package org.coner.api.entity;
 
-import org.coner.util.*;
+import static io.dropwizard.testing.FixtureHelpers.fixture;
+import static org.fest.assertions.Assertions.assertThat;
+
+import org.coner.util.ApiEntityTestUtils;
+import org.coner.util.JacksonUtil;
+import org.junit.Before;
+import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.jackson.Jackson;
-import org.junit.*;
-import org.skyscreamer.jsonassert.JSONAssert;
-
-import static io.dropwizard.testing.FixtureHelpers.fixture;
-import static org.fest.assertions.Assertions.assertThat;
 
 public class EventApiEntityTest {
 

--- a/dropwizard-app/src/test/java/org/coner/api/entity/HandicapGroupApiEntityTest.java
+++ b/dropwizard-app/src/test/java/org/coner/api/entity/HandicapGroupApiEntityTest.java
@@ -1,14 +1,16 @@
 package org.coner.api.entity;
 
-import org.coner.util.*;
+import static io.dropwizard.testing.FixtureHelpers.fixture;
+import static org.fest.assertions.Assertions.assertThat;
+
+import org.coner.util.ApiEntityTestUtils;
+import org.coner.util.JacksonUtil;
+import org.junit.Before;
+import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.jackson.Jackson;
-import org.junit.*;
-import org.skyscreamer.jsonassert.JSONAssert;
-
-import static io.dropwizard.testing.FixtureHelpers.fixture;
-import static org.fest.assertions.Assertions.assertThat;
 
 public class HandicapGroupApiEntityTest {
     private final String fixturePath = "fixtures/api/entity/handicap_group_full.json";

--- a/dropwizard-app/src/test/java/org/coner/api/entity/RegistrationApiEntityTest.java
+++ b/dropwizard-app/src/test/java/org/coner/api/entity/RegistrationApiEntityTest.java
@@ -1,14 +1,16 @@
 package org.coner.api.entity;
 
-import org.coner.util.*;
+import static io.dropwizard.testing.FixtureHelpers.fixture;
+import static org.fest.assertions.Assertions.assertThat;
+
+import org.coner.util.ApiEntityTestUtils;
+import org.coner.util.JacksonUtil;
+import org.junit.Before;
+import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.jackson.Jackson;
-import org.junit.*;
-import org.skyscreamer.jsonassert.JSONAssert;
-
-import static io.dropwizard.testing.FixtureHelpers.fixture;
-import static org.fest.assertions.Assertions.assertThat;
 
 public class RegistrationApiEntityTest {
     private final String fixturePath = "fixtures/api/entity/registration_full.json";

--- a/dropwizard-app/src/test/java/org/coner/boundary/AbstractBoundaryTest.java
+++ b/dropwizard-app/src/test/java/org/coner/boundary/AbstractBoundaryTest.java
@@ -1,23 +1,26 @@
 package org.coner.boundary;
 
-import org.coner.api.entity.ApiEntity;
-import org.coner.core.domain.entity.DomainEntity;
-import org.coner.hibernate.entity.HibernateEntity;
-import org.coner.util.merger.ObjectMerger;
-
-import java.lang.reflect.InvocationTargetException;
-import java.util.*;
-import org.junit.*;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
-
 import static org.assertj.core.api.Fail.failBecauseExceptionWasNotThrown;
 import static org.fest.assertions.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import org.coner.api.entity.ApiEntity;
+import org.coner.core.domain.entity.DomainEntity;
+import org.coner.hibernate.entity.HibernateEntity;
+import org.coner.util.merger.ObjectMerger;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AbstractBoundaryTest {

--- a/dropwizard-app/src/test/java/org/coner/core/ConerCoreServiceTest.java
+++ b/dropwizard-app/src/test/java/org/coner/core/ConerCoreServiceTest.java
@@ -1,16 +1,5 @@
 package org.coner.core;
 
-import org.coner.core.domain.entity.*;
-import org.coner.core.domain.payload.*;
-import org.coner.core.domain.service.*;
-import org.coner.util.TestConstants;
-
-import java.util.*;
-import org.junit.*;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Fail.failBecauseExceptionWasNotThrown;
 import static org.mockito.Mockito.mock;
@@ -18,6 +7,27 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.coner.core.domain.entity.Event;
+import org.coner.core.domain.entity.Registration;
+import org.coner.core.domain.payload.CompetitionGroupAddPayload;
+import org.coner.core.domain.payload.EventAddPayload;
+import org.coner.core.domain.payload.HandicapGroupAddPayload;
+import org.coner.core.domain.service.CompetitionGroupService;
+import org.coner.core.domain.service.CompetitionGroupSetService;
+import org.coner.core.domain.service.EventService;
+import org.coner.core.domain.service.HandicapGroupService;
+import org.coner.core.domain.service.HandicapGroupSetService;
+import org.coner.core.domain.service.RegistrationService;
+import org.coner.util.TestConstants;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ConerCoreServiceTest {

--- a/dropwizard-app/src/test/java/org/coner/core/domain/service/AbstractDomainServiceTest.java
+++ b/dropwizard-app/src/test/java/org/coner/core/domain/service/AbstractDomainServiceTest.java
@@ -1,21 +1,22 @@
 package org.coner.core.domain.service;
 
-import org.coner.core.domain.entity.DomainEntity;
-import org.coner.core.domain.payload.DomainAddPayload;
-import org.coner.core.exception.EntityNotFoundException;
-import org.coner.core.gateway.Gateway;
-
-import java.util.List;
-import org.junit.*;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.coner.core.domain.entity.DomainEntity;
+import org.coner.core.domain.payload.DomainAddPayload;
+import org.coner.core.exception.EntityNotFoundException;
+import org.coner.core.gateway.Gateway;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AbstractDomainServiceTest {

--- a/dropwizard-app/src/test/java/org/coner/hibernate/dao/AbstractDaoTest.java
+++ b/dropwizard-app/src/test/java/org/coner/hibernate/dao/AbstractDaoTest.java
@@ -1,9 +1,8 @@
 package org.coner.hibernate.dao;
 
-import org.coner.hibernate.entity.*;
-
-import java.sql.*;
-import java.util.*;
+import org.coner.hibernate.entity.EventHibernateEntity;
+import org.coner.hibernate.entity.HibernateEntity;
+import org.coner.hibernate.entity.RegistrationHibernateEntity;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.cfg.AvailableSettings;

--- a/dropwizard-app/src/test/java/org/coner/hibernate/dao/EventDaoTest.java
+++ b/dropwizard-app/src/test/java/org/coner/hibernate/dao/EventDaoTest.java
@@ -1,13 +1,16 @@
 package org.coner.hibernate.dao;
 
-import org.coner.hibernate.entity.EventHibernateEntity;
+import static org.fest.assertions.Assertions.assertThat;
 
 import java.time.ZonedDateTime;
-import java.util.*;
-import org.hibernate.Query;
-import org.junit.*;
+import java.util.Date;
+import java.util.List;
 
-import static org.fest.assertions.Assertions.assertThat;
+import org.coner.hibernate.entity.EventHibernateEntity;
+import org.hibernate.Query;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
 public class EventDaoTest extends AbstractDaoTest {
 

--- a/dropwizard-app/src/test/java/org/coner/it/AbstractIntegrationTest.java
+++ b/dropwizard-app/src/test/java/org/coner/it/AbstractIntegrationTest.java
@@ -1,10 +1,13 @@
 package org.coner.it;
 
+import javax.ws.rs.client.Client;
+
 import org.coner.ConerDropwizardConfiguration;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
 
 import io.dropwizard.testing.junit.DropwizardAppRule;
-import javax.ws.rs.client.Client;
-import org.junit.*;
 
 public class AbstractIntegrationTest {
     protected AbstractIntegrationTest() {

--- a/dropwizard-app/src/test/java/org/coner/it/CompetitionGroupIntegrationTest.java
+++ b/dropwizard-app/src/test/java/org/coner/it/CompetitionGroupIntegrationTest.java
@@ -1,17 +1,23 @@
 package org.coner.it;
 
-import org.coner.api.entity.*;
-import org.coner.api.request.*;
-import org.coner.api.response.*;
-import org.coner.util.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.URI;
+
 import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.*;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.coner.api.entity.CompetitionGroupApiEntity;
+import org.coner.api.entity.CompetitionGroupSetApiEntity;
+import org.coner.api.request.AddCompetitionGroupRequest;
+import org.coner.api.request.AddCompetitionGroupSetRequest;
+import org.coner.api.response.ErrorsResponse;
+import org.coner.api.response.GetCompetitionGroupSetsResponse;
+import org.coner.util.TestConstants;
+import org.coner.util.UnitTestUtils;
 import org.eclipse.jetty.http.HttpStatus;
 import org.junit.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class CompetitionGroupIntegrationTest extends AbstractIntegrationTest {
 

--- a/dropwizard-app/src/test/java/org/coner/it/EventIntegrationTest.java
+++ b/dropwizard-app/src/test/java/org/coner/it/EventIntegrationTest.java
@@ -1,19 +1,22 @@
 package org.coner.it;
 
-import org.coner.api.entity.EventApiEntity;
-import org.coner.api.request.AddEventRequest;
-import org.coner.api.response.*;
-import org.coner.util.UnitTestUtils;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.URI;
 import java.time.ZonedDateTime;
 import java.util.Date;
+
 import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.*;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.coner.api.entity.EventApiEntity;
+import org.coner.api.request.AddEventRequest;
+import org.coner.api.response.ErrorsResponse;
+import org.coner.api.response.GetEventsResponse;
+import org.coner.util.UnitTestUtils;
 import org.eclipse.jetty.http.HttpStatus;
 import org.junit.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 
 public class EventIntegrationTest extends AbstractIntegrationTest {

--- a/dropwizard-app/src/test/java/org/coner/it/HandicapGroupIntegrationTest.java
+++ b/dropwizard-app/src/test/java/org/coner/it/HandicapGroupIntegrationTest.java
@@ -1,18 +1,21 @@
 package org.coner.it;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
 import org.coner.api.entity.HandicapGroupApiEntity;
 import org.coner.api.request.AddHandicapGroupRequest;
 import org.coner.api.request.AddHandicapGroupSetRequest;
 import org.coner.api.response.ErrorsResponse;
-import org.coner.util.*;
-
-import java.net.URI;
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.*;
+import org.coner.util.TestConstants;
+import org.coner.util.UnitTestUtils;
 import org.eclipse.jetty.http.HttpStatus;
 import org.junit.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class HandicapGroupIntegrationTest extends AbstractIntegrationTest {
 

--- a/dropwizard-app/src/test/java/org/coner/it/IntegrationTestUtils.java
+++ b/dropwizard-app/src/test/java/org/coner/it/IntegrationTestUtils.java
@@ -1,13 +1,15 @@
 package org.coner.it;
 
-import org.coner.*;
+import javax.ws.rs.client.Client;
+
+import org.coner.ConerDropwizardApplication;
+import org.coner.ConerDropwizardConfiguration;
+import org.glassfish.jersey.uri.internal.JerseyUriBuilder;
 
 import com.google.common.base.Joiner;
 import io.dropwizard.client.JerseyClientBuilder;
 import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit.DropwizardAppRule;
-import javax.ws.rs.client.Client;
-import org.glassfish.jersey.uri.internal.JerseyUriBuilder;
 
 public final class IntegrationTestUtils {
 

--- a/dropwizard-app/src/test/java/org/coner/it/RegistrationIntegrationTest.java
+++ b/dropwizard-app/src/test/java/org/coner/it/RegistrationIntegrationTest.java
@@ -1,23 +1,27 @@
 package org.coner.it;
 
-import org.coner.api.entity.RegistrationApiEntity;
-import org.coner.api.request.*;
-import org.coner.api.response.*;
-import org.coner.util.UnitTestUtils;
-
-import java.net.URI;
-import java.util.List;
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.*;
-import org.eclipse.jetty.http.HttpStatus;
-import org.junit.*;
-
 import static org.coner.util.TestConstants.EVENT_DATE;
 import static org.coner.util.TestConstants.EVENT_NAME;
 import static org.coner.util.TestConstants.REGISTRATION_FIRSTNAME;
 import static org.coner.util.TestConstants.REGISTRATION_LASTNAME;
-
 import static org.fest.assertions.Assertions.assertThat;
+
+import java.net.URI;
+import java.util.List;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.coner.api.entity.RegistrationApiEntity;
+import org.coner.api.request.AddEventRequest;
+import org.coner.api.request.AddRegistrationRequest;
+import org.coner.api.response.ErrorsResponse;
+import org.coner.api.response.GetEventRegistrationsResponse;
+import org.coner.util.UnitTestUtils;
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.Before;
+import org.junit.Test;
 
 public class RegistrationIntegrationTest extends AbstractIntegrationTest {
 

--- a/dropwizard-app/src/test/java/org/coner/resource/CompetitionGroupResourceTest.java
+++ b/dropwizard-app/src/test/java/org/coner/resource/CompetitionGroupResourceTest.java
@@ -1,23 +1,28 @@
 package org.coner.resource;
 
-import org.coner.api.entity.CompetitionGroupApiEntity;
-import org.coner.boundary.CompetitionGroupApiDomainBoundary;
-import org.coner.core.ConerCoreService;
-import org.coner.core.domain.entity.CompetitionGroup;
-import org.coner.core.exception.EntityNotFoundException;
-import org.coner.util.*;
-
-import io.dropwizard.testing.junit.ResourceTestRule;
-import javax.ws.rs.core.*;
-import org.eclipse.jetty.http.HttpStatus;
-import org.junit.*;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.coner.api.entity.CompetitionGroupApiEntity;
+import org.coner.boundary.CompetitionGroupApiDomainBoundary;
+import org.coner.core.ConerCoreService;
+import org.coner.core.domain.entity.CompetitionGroup;
+import org.coner.core.exception.EntityNotFoundException;
+import org.coner.util.ApiEntityTestUtils;
+import org.coner.util.TestConstants;
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import io.dropwizard.testing.junit.ResourceTestRule;
 
 public class CompetitionGroupResourceTest {
 

--- a/dropwizard-app/src/test/java/org/coner/resource/CompetitionGroupSetResourceTest.java
+++ b/dropwizard-app/src/test/java/org/coner/resource/CompetitionGroupSetResourceTest.java
@@ -1,27 +1,31 @@
 package org.coner.resource;
 
-import org.coner.api.entity.CompetitionGroupSetApiEntity;
-import org.coner.boundary.CompetitionGroupSetApiDomainBoundary;
-import org.coner.core.ConerCoreService;
-import org.coner.core.domain.entity.CompetitionGroupSet;
-import org.coner.core.exception.EntityNotFoundException;
-import org.coner.util.*;
-
-import io.dropwizard.testing.junit.ResourceTestRule;
-import javax.ws.rs.core.*;
-import org.eclipse.jetty.http.HttpStatus;
-import org.junit.*;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
-
-import static org.coner.util.TestConstants.COMPETITION_GROUP_SET_ID;
-
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.coner.util.TestConstants.COMPETITION_GROUP_SET_ID;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.coner.api.entity.CompetitionGroupSetApiEntity;
+import org.coner.boundary.CompetitionGroupSetApiDomainBoundary;
+import org.coner.core.ConerCoreService;
+import org.coner.core.domain.entity.CompetitionGroupSet;
+import org.coner.core.exception.EntityNotFoundException;
+import org.coner.util.ApiEntityTestUtils;
+import org.coner.util.DomainEntityTestUtils;
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import io.dropwizard.testing.junit.ResourceTestRule;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CompetitionGroupSetResourceTest {

--- a/dropwizard-app/src/test/java/org/coner/resource/CompetitionGroupSetsResourceTest.java
+++ b/dropwizard-app/src/test/java/org/coner/resource/CompetitionGroupSetsResourceTest.java
@@ -1,30 +1,36 @@
 package org.coner.resource;
 
-import org.coner.api.entity.CompetitionGroupSetApiEntity;
-import org.coner.api.request.AddCompetitionGroupSetRequest;
-import org.coner.boundary.*;
-import org.coner.core.ConerCoreService;
-import org.coner.core.domain.entity.CompetitionGroupSet;
-import org.coner.core.domain.payload.CompetitionGroupSetAddPayload;
-import org.coner.util.*;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.dropwizard.jackson.Jackson;
-import io.dropwizard.testing.FixtureHelpers;
-import io.dropwizard.testing.junit.ResourceTestRule;
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.*;
-import org.eclipse.jetty.http.HttpStatus;
-import org.junit.*;
-
-import static org.coner.util.TestConstants.COMPETITION_GROUP_SET_ID;
-
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.coner.util.TestConstants.COMPETITION_GROUP_SET_ID;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.coner.api.entity.CompetitionGroupSetApiEntity;
+import org.coner.api.request.AddCompetitionGroupSetRequest;
+import org.coner.boundary.CompetitionGroupSetApiAddPayloadBoundary;
+import org.coner.boundary.CompetitionGroupSetApiDomainBoundary;
+import org.coner.core.ConerCoreService;
+import org.coner.core.domain.entity.CompetitionGroupSet;
+import org.coner.core.domain.payload.CompetitionGroupSetAddPayload;
+import org.coner.util.ApiEntityTestUtils;
+import org.coner.util.JacksonUtil;
+import org.coner.util.UnitTestUtils;
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.dropwizard.jackson.Jackson;
+import io.dropwizard.testing.FixtureHelpers;
+import io.dropwizard.testing.junit.ResourceTestRule;
 
 public class CompetitionGroupSetsResourceTest {
 

--- a/dropwizard-app/src/test/java/org/coner/resource/CompetitionGroupsResourceTest.java
+++ b/dropwizard-app/src/test/java/org/coner/resource/CompetitionGroupsResourceTest.java
@@ -1,34 +1,44 @@
 package org.coner.resource;
 
-import org.coner.api.entity.CompetitionGroupApiEntity;
-import org.coner.api.request.AddCompetitionGroupRequest;
-import org.coner.api.response.*;
-import org.coner.boundary.*;
-import org.coner.core.ConerCoreService;
-import org.coner.core.domain.entity.CompetitionGroup;
-import org.coner.core.domain.payload.CompetitionGroupAddPayload;
-import org.coner.util.*;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.dropwizard.jackson.Jackson;
-import io.dropwizard.testing.junit.ResourceTestRule;
-import java.util.*;
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.*;
-import org.eclipse.jetty.http.HttpStatus;
-import org.junit.*;
-import org.mockito.MockitoAnnotations;
-
-import static org.coner.util.TestConstants.COMPETITION_GROUP_ID;
-
 import static io.dropwizard.testing.FixtureHelpers.fixture;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.coner.util.TestConstants.COMPETITION_GROUP_ID;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.List;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.coner.api.entity.CompetitionGroupApiEntity;
+import org.coner.api.request.AddCompetitionGroupRequest;
+import org.coner.api.response.ErrorsResponse;
+import org.coner.api.response.GetCompetitionGroupsResponse;
+import org.coner.boundary.CompetitionGroupApiAddPayloadBoundary;
+import org.coner.boundary.CompetitionGroupApiDomainBoundary;
+import org.coner.core.ConerCoreService;
+import org.coner.core.domain.entity.CompetitionGroup;
+import org.coner.core.domain.payload.CompetitionGroupAddPayload;
+import org.coner.util.ApiEntityTestUtils;
+import org.coner.util.DomainEntityTestUtils;
+import org.coner.util.JacksonUtil;
+import org.coner.util.UnitTestUtils;
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.MockitoAnnotations;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.dropwizard.jackson.Jackson;
+import io.dropwizard.testing.junit.ResourceTestRule;
 
 public class CompetitionGroupsResourceTest {
 

--- a/dropwizard-app/src/test/java/org/coner/resource/EventRegistrationResourceTest.java
+++ b/dropwizard-app/src/test/java/org/coner/resource/EventRegistrationResourceTest.java
@@ -1,26 +1,31 @@
 package org.coner.resource;
 
-import org.coner.api.entity.RegistrationApiEntity;
-import org.coner.boundary.RegistrationApiDomainBoundary;
-import org.coner.core.ConerCoreService;
-import org.coner.core.domain.entity.Registration;
-import org.coner.core.exception.*;
-import org.coner.util.*;
-
-import io.dropwizard.testing.junit.ResourceTestRule;
-import javax.ws.rs.core.*;
-import org.eclipse.jetty.http.HttpStatus;
-import org.junit.*;
-
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.coner.util.TestConstants.EVENT_ID;
 import static org.coner.util.TestConstants.REGISTRATION_ID;
-
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.coner.api.entity.RegistrationApiEntity;
+import org.coner.boundary.RegistrationApiDomainBoundary;
+import org.coner.core.ConerCoreService;
+import org.coner.core.domain.entity.Registration;
+import org.coner.core.exception.EntityNotFoundException;
+import org.coner.core.exception.EventMismatchException;
+import org.coner.util.ApiEntityTestUtils;
+import org.coner.util.DomainEntityTestUtils;
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import io.dropwizard.testing.junit.ResourceTestRule;
 
 public class EventRegistrationResourceTest {
 

--- a/dropwizard-app/src/test/java/org/coner/resource/EventRegistrationsResourceTest.java
+++ b/dropwizard-app/src/test/java/org/coner/resource/EventRegistrationsResourceTest.java
@@ -1,34 +1,42 @@
 package org.coner.resource;
 
-import org.coner.api.entity.RegistrationApiEntity;
-import org.coner.api.request.AddRegistrationRequest;
-import org.coner.api.response.GetEventRegistrationsResponse;
-import org.coner.boundary.*;
-import org.coner.core.ConerCoreService;
-import org.coner.core.domain.entity.Registration;
-import org.coner.core.domain.payload.RegistrationAddPayload;
-import org.coner.core.exception.EntityNotFoundException;
-import org.coner.util.*;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.dropwizard.jackson.Jackson;
-import io.dropwizard.testing.FixtureHelpers;
-import io.dropwizard.testing.junit.ResourceTestRule;
-import java.util.*;
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.*;
-import org.eclipse.jetty.http.HttpStatus;
-import org.junit.*;
-
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.coner.util.TestConstants.EVENT_ID;
 import static org.coner.util.TestConstants.REGISTRATION_ID;
-
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.List;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.coner.api.entity.RegistrationApiEntity;
+import org.coner.api.request.AddRegistrationRequest;
+import org.coner.api.response.GetEventRegistrationsResponse;
+import org.coner.boundary.RegistrationApiAddPayloadBoundary;
+import org.coner.boundary.RegistrationApiDomainBoundary;
+import org.coner.core.ConerCoreService;
+import org.coner.core.domain.entity.Registration;
+import org.coner.core.domain.payload.RegistrationAddPayload;
+import org.coner.core.exception.EntityNotFoundException;
+import org.coner.util.ApiEntityTestUtils;
+import org.coner.util.DomainEntityTestUtils;
+import org.coner.util.JacksonUtil;
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.dropwizard.jackson.Jackson;
+import io.dropwizard.testing.FixtureHelpers;
+import io.dropwizard.testing.junit.ResourceTestRule;
 
 public class EventRegistrationsResourceTest {
 

--- a/dropwizard-app/src/test/java/org/coner/resource/EventResourceTest.java
+++ b/dropwizard-app/src/test/java/org/coner/resource/EventResourceTest.java
@@ -1,25 +1,29 @@
 package org.coner.resource;
 
-import org.coner.api.entity.EventApiEntity;
-import org.coner.boundary.EventApiDomainBoundary;
-import org.coner.core.ConerCoreService;
-import org.coner.core.domain.entity.Event;
-import org.coner.core.exception.EntityNotFoundException;
-import org.coner.util.*;
-
-import io.dropwizard.testing.junit.ResourceTestRule;
-import javax.ws.rs.core.*;
-import org.eclipse.jetty.http.HttpStatus;
-import org.junit.*;
-
-import static org.coner.util.TestConstants.EVENT_ID;
-
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.coner.util.TestConstants.EVENT_ID;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.coner.api.entity.EventApiEntity;
+import org.coner.boundary.EventApiDomainBoundary;
+import org.coner.core.ConerCoreService;
+import org.coner.core.domain.entity.Event;
+import org.coner.core.exception.EntityNotFoundException;
+import org.coner.util.ApiEntityTestUtils;
+import org.coner.util.DomainEntityTestUtils;
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import io.dropwizard.testing.junit.ResourceTestRule;
 
 public class EventResourceTest {
 

--- a/dropwizard-app/src/test/java/org/coner/resource/EventsResourceTest.java
+++ b/dropwizard-app/src/test/java/org/coner/resource/EventsResourceTest.java
@@ -1,24 +1,5 @@
 package org.coner.resource;
 
-import org.coner.api.entity.EventApiEntity;
-import org.coner.api.request.AddEventRequest;
-import org.coner.api.response.*;
-import org.coner.boundary.*;
-import org.coner.core.ConerCoreService;
-import org.coner.core.domain.entity.Event;
-import org.coner.core.domain.payload.EventAddPayload;
-import org.coner.util.*;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.dropwizard.jackson.Jackson;
-import io.dropwizard.testing.FixtureHelpers;
-import io.dropwizard.testing.junit.ResourceTestRule;
-import java.util.*;
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.*;
-import org.eclipse.jetty.http.HttpStatus;
-import org.junit.*;
-
 import static org.fest.assertions.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
@@ -26,6 +7,34 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.coner.api.entity.EventApiEntity;
+import org.coner.api.request.AddEventRequest;
+import org.coner.api.response.ErrorsResponse;
+import org.coner.api.response.GetEventsResponse;
+import org.coner.boundary.EventApiAddPayloadBoundary;
+import org.coner.boundary.EventApiDomainBoundary;
+import org.coner.core.ConerCoreService;
+import org.coner.core.domain.entity.Event;
+import org.coner.core.domain.payload.EventAddPayload;
+import org.coner.util.ApiEntityTestUtils;
+import org.coner.util.JacksonUtil;
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.dropwizard.jackson.Jackson;
+import io.dropwizard.testing.FixtureHelpers;
+import io.dropwizard.testing.junit.ResourceTestRule;
 
 public class EventsResourceTest {
 

--- a/dropwizard-app/src/test/java/org/coner/resource/HandicapGroupResourceTest.java
+++ b/dropwizard-app/src/test/java/org/coner/resource/HandicapGroupResourceTest.java
@@ -1,26 +1,30 @@
 package org.coner.resource;
 
-import org.coner.api.entity.HandicapGroupApiEntity;
-import org.coner.boundary.HandicapGroupApiDomainBoundary;
-import org.coner.core.ConerCoreService;
-import org.coner.core.domain.entity.HandicapGroup;
-import org.coner.core.exception.EntityNotFoundException;
-import org.coner.util.*;
-
-import io.dropwizard.testing.junit.ResourceTestRule;
-import javax.ws.rs.core.*;
-import org.eclipse.jetty.http.HttpStatus;
-import org.junit.*;
-
-import static org.coner.util.TestConstants.HANDICAP_GROUP_ID;
-
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.coner.util.TestConstants.HANDICAP_GROUP_ID;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.coner.api.entity.HandicapGroupApiEntity;
+import org.coner.boundary.HandicapGroupApiDomainBoundary;
+import org.coner.core.ConerCoreService;
+import org.coner.core.domain.entity.HandicapGroup;
+import org.coner.core.exception.EntityNotFoundException;
+import org.coner.util.ApiEntityTestUtils;
+import org.coner.util.DomainEntityTestUtils;
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import io.dropwizard.testing.junit.ResourceTestRule;
 
 public class HandicapGroupResourceTest {
 

--- a/dropwizard-app/src/test/java/org/coner/resource/HandicapGroupSetsResourceTest.java
+++ b/dropwizard-app/src/test/java/org/coner/resource/HandicapGroupSetsResourceTest.java
@@ -1,27 +1,34 @@
 package org.coner.resource;
 
-import org.coner.api.entity.HandicapGroupSetApiEntity;
-import org.coner.api.request.AddHandicapGroupSetRequest;
-import org.coner.boundary.*;
-import org.coner.core.ConerCoreService;
-import org.coner.core.domain.entity.HandicapGroupSet;
-import org.coner.core.domain.payload.HandicapGroupSetAddPayload;
-import org.coner.util.*;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.dropwizard.jackson.Jackson;
-import io.dropwizard.testing.FixtureHelpers;
-import io.dropwizard.testing.junit.ResourceTestRule;
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.*;
-import org.eclipse.jetty.http.HttpStatus;
-import org.junit.*;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.coner.api.entity.HandicapGroupSetApiEntity;
+import org.coner.api.request.AddHandicapGroupSetRequest;
+import org.coner.boundary.HandicapGroupSetApiAddPayloadBoundary;
+import org.coner.boundary.HandicapGroupSetApiDomainBoundary;
+import org.coner.core.ConerCoreService;
+import org.coner.core.domain.entity.HandicapGroupSet;
+import org.coner.core.domain.payload.HandicapGroupSetAddPayload;
+import org.coner.util.JacksonUtil;
+import org.coner.util.TestConstants;
+import org.coner.util.UnitTestUtils;
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.dropwizard.jackson.Jackson;
+import io.dropwizard.testing.FixtureHelpers;
+import io.dropwizard.testing.junit.ResourceTestRule;
 
 public class HandicapGroupSetsResourceTest {
 

--- a/dropwizard-app/src/test/java/org/coner/resource/HandicapGroupsResourceTest.java
+++ b/dropwizard-app/src/test/java/org/coner/resource/HandicapGroupsResourceTest.java
@@ -1,27 +1,6 @@
 package org.coner.resource;
 
-import org.coner.api.entity.HandicapGroupApiEntity;
-import org.coner.api.request.AddHandicapGroupRequest;
-import org.coner.api.response.*;
-import org.coner.boundary.*;
-import org.coner.core.ConerCoreService;
-import org.coner.core.domain.entity.HandicapGroup;
-import org.coner.core.domain.payload.HandicapGroupAddPayload;
-import org.coner.util.*;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.dropwizard.jackson.Jackson;
-import io.dropwizard.testing.FixtureHelpers;
-import io.dropwizard.testing.junit.ResourceTestRule;
-import java.util.*;
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.*;
-import org.eclipse.jetty.http.HttpStatus;
-import org.junit.*;
-import org.mockito.MockitoAnnotations;
-
 import static org.coner.util.TestConstants.HANDICAP_GROUP_ID;
-
 import static org.fest.assertions.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
@@ -30,6 +9,37 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.coner.api.entity.HandicapGroupApiEntity;
+import org.coner.api.request.AddHandicapGroupRequest;
+import org.coner.api.response.ErrorsResponse;
+import org.coner.api.response.GetHandicapGroupsResponse;
+import org.coner.boundary.HandicapGroupApiAddPayloadBoundary;
+import org.coner.boundary.HandicapGroupApiDomainBoundary;
+import org.coner.core.ConerCoreService;
+import org.coner.core.domain.entity.HandicapGroup;
+import org.coner.core.domain.payload.HandicapGroupAddPayload;
+import org.coner.util.ApiEntityTestUtils;
+import org.coner.util.DomainEntityTestUtils;
+import org.coner.util.JacksonUtil;
+import org.coner.util.UnitTestUtils;
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.MockitoAnnotations;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.dropwizard.jackson.Jackson;
+import io.dropwizard.testing.FixtureHelpers;
+import io.dropwizard.testing.junit.ResourceTestRule;
 
 public class HandicapGroupsResourceTest {
     private final ConerCoreService conerCoreService = mock(ConerCoreService.class);

--- a/dropwizard-app/src/test/java/org/coner/util/ApiEntityTestUtils.java
+++ b/dropwizard-app/src/test/java/org/coner/util/ApiEntityTestUtils.java
@@ -1,11 +1,18 @@
 package org.coner.util;
 
-import org.coner.api.entity.*;
+import java.math.BigDecimal;
+import java.util.Date;
+import java.util.Set;
+
+import org.coner.api.entity.CompetitionGroupApiEntity;
+import org.coner.api.entity.CompetitionGroupSetApiEntity;
+import org.coner.api.entity.EventApiEntity;
+import org.coner.api.entity.HandicapGroupApiEntity;
+import org.coner.api.entity.HandicapGroupSetApiEntity;
+import org.coner.api.entity.RegistrationApiEntity;
 import org.coner.api.request.AddHandicapGroupSetRequest;
 
 import com.google.common.collect.Sets;
-import java.math.BigDecimal;
-import java.util.*;
 
 public final class ApiEntityTestUtils {
 

--- a/dropwizard-app/src/test/java/org/coner/util/DomainEntityTestUtils.java
+++ b/dropwizard-app/src/test/java/org/coner/util/DomainEntityTestUtils.java
@@ -1,10 +1,17 @@
 package org.coner.util;
 
-import org.coner.core.domain.entity.*;
+import java.math.BigDecimal;
+import java.util.Date;
+import java.util.Set;
+
+import org.coner.core.domain.entity.CompetitionGroup;
+import org.coner.core.domain.entity.CompetitionGroupSet;
+import org.coner.core.domain.entity.Event;
+import org.coner.core.domain.entity.HandicapGroup;
+import org.coner.core.domain.entity.HandicapGroupSet;
+import org.coner.core.domain.entity.Registration;
 
 import com.google.common.collect.Sets;
-import java.math.BigDecimal;
-import java.util.*;
 
 public final class DomainEntityTestUtils {
 

--- a/dropwizard-app/src/test/java/org/coner/util/HibernateEntityUtils.java
+++ b/dropwizard-app/src/test/java/org/coner/util/HibernateEntityUtils.java
@@ -1,8 +1,8 @@
 package org.coner.util;
 
-import org.coner.hibernate.entity.EventHibernateEntity;
-
 import java.util.Date;
+
+import org.coner.hibernate.entity.EventHibernateEntity;
 
 /**
  *

--- a/dropwizard-app/src/test/java/org/coner/util/TestConstants.java
+++ b/dropwizard-app/src/test/java/org/coner/util/TestConstants.java
@@ -1,10 +1,10 @@
 package org.coner.util;
 
-import org.coner.core.domain.entity.CompetitionGroup;
-
 import java.math.BigDecimal;
 import java.time.ZonedDateTime;
 import java.util.Date;
+
+import org.coner.core.domain.entity.CompetitionGroup;
 
 public final class TestConstants {
 

--- a/dropwizard-app/src/test/java/org/coner/util/UnitTestUtils.java
+++ b/dropwizard-app/src/test/java/org/coner/util/UnitTestUtils.java
@@ -1,6 +1,7 @@
 package org.coner.util;
 
 import javax.ws.rs.core.Response;
+
 import org.apache.commons.lang3.StringUtils;
 
 /**

--- a/dropwizard-app/src/test/java/org/coner/util/merger/JavaBeanClassInspectorTest.java
+++ b/dropwizard-app/src/test/java/org/coner/util/merger/JavaBeanClassInspectorTest.java
@@ -1,10 +1,12 @@
 package org.coner.util.merger;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.lang.reflect.Method;
 import java.util.Set;
-import org.junit.*;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.Before;
+import org.junit.Test;
 
 public class JavaBeanClassInspectorTest {
 

--- a/dropwizard-app/src/test/java/org/coner/util/merger/PayloadClassInspectorTest.java
+++ b/dropwizard-app/src/test/java/org/coner/util/merger/PayloadClassInspectorTest.java
@@ -1,9 +1,11 @@
 package org.coner.util.merger;
 
-import java.lang.reflect.Field;
-import org.junit.*;
-
 import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Field;
+
+import org.junit.Before;
+import org.junit.Test;
 
 public class PayloadClassInspectorTest {
 

--- a/dropwizard-app/src/test/java/org/coner/util/merger/ReflectionJavaBeanMergerTest.java
+++ b/dropwizard-app/src/test/java/org/coner/util/merger/ReflectionJavaBeanMergerTest.java
@@ -1,8 +1,9 @@
 package org.coner.util.merger;
 
-import org.junit.*;
-
 import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
 
 public class ReflectionJavaBeanMergerTest {
 

--- a/dropwizard-app/src/test/java/org/coner/util/merger/ReflectionPayloadJavaBeanMergerTest.java
+++ b/dropwizard-app/src/test/java/org/coner/util/merger/ReflectionPayloadJavaBeanMergerTest.java
@@ -1,11 +1,10 @@
 package org.coner.util.merger;
 
-import org.junit.Test;
-
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.coner.util.merger.ReflectionPayloadJavaBeanMerger.javaBeanToPayload;
 import static org.coner.util.merger.ReflectionPayloadJavaBeanMerger.payloadToJavaBean;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.Test;
 
 public class ReflectionPayloadJavaBeanMergerTest {
 

--- a/pom.xml
+++ b/pom.xml
@@ -39,19 +39,29 @@
                 <configuration>
                     <configLocation>build-tools/src/main/resources/checkstyle/checkstyle.xml</configLocation>
                     <includeTestSourceDirectory>true</includeTestSourceDirectory>
-                    <suppressionsLocation>checkstyle/suppressions.xml</suppressionsLocation>
+                    <suppressionsLocation>build-tools/src/main/resources/checkstyle/suppressions.xml</suppressionsLocation>
                     <linkXRef>false</linkXRef>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>checkstyle</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <failOnViolation>true</failOnViolation>
+                            <encoding>UTF-8</encoding>
+                            <failsOnError>true</failsOnError>
+                            <linkXRef>false</linkXRef>
+                        </configuration>
+                    </execution>
+                </executions>
                 <dependencies>
-                    <dependency>
-                        <groupId>org.coner</groupId>
-                        <artifactId>build-tools</artifactId>
-                        <version>1.0</version>
-                    </dependency>
                     <dependency>
                         <groupId>com.puppycrawl.tools</groupId>
                         <artifactId>checkstyle</artifactId>
-                        <version>6.11.2</version>
+                        <version>6.19</version>
                     </dependency>
                 </dependencies>
             </plugin>


### PR DESCRIPTION
Few notes:

I made checkstyle:check run during the validate phase so the travis ci config could be changed to be simply `mvn test`.

My intellij  config for imports (Editor -> Codestyle -> Java) has imports (for cmd+alt+o):

 - import static all other imports
 - blank line
 - import java.*
 - blank line
 - import javax.*
 - blank line
 - import org.*
 - blank line
 - import all other imports